### PR TITLE
Expose a listener API to get real time active message count

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -269,16 +269,16 @@ func (l *Listener) Close(ctx context.Context) error {
 }
 
 // GetActiveMessageCount gets the active message count of a topic subscription
+// WARNING: GetActiveMessageCount is 10 times expensive than a call to receive a message
 func (l *Listener) GetActiveMessageCount(ctx context.Context, topicName, subscriptionName string) (int32, error) {
-	topicEntity, err := getTopicEntity(ctx, topicName, l.namespace)
-	if err != nil {
-		return 0, fmt.Errorf("error to get entity of topic %q: %s", topicName, err)
+	if l.topicEntity == nil {
+		return 0, fmt.Errorf("entity of topic is nil")
 	}
-	if topicEntity == nil {
-		return 0, fmt.Errorf("entity of topic %q returned is nil", topicName)
+	if l.topicName != topicName {
+		return 0, fmt.Errorf("topic name %q doesn't match %q", topicName, l.topicName)
 	}
 
-	subscriptionEntity, err := getSubscriptionEntity(ctx, subscriptionName, l.namespace, topicEntity)
+	subscriptionEntity, err := getSubscriptionEntity(ctx, subscriptionName, l.namespace, l.topicEntity)
 	if err != nil {
 		return 0, fmt.Errorf("error to get entity of subscription %q of topic %q: %s", subscriptionName, topicName, err)
 	}

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -79,6 +79,7 @@ func WithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientI
 	}
 }
 
+// WithToken configures a listener with a AAD token
 func WithToken(serviceBusNamespaceName string, spt *adal.ServicePrincipalToken) ManagementOption {
 	return func(l *Listener) error {
 		if spt == nil {
@@ -156,7 +157,7 @@ func setTopicEntity(ctx context.Context, l *Listener) error {
 	if l.topicEntity != nil {
 		return nil
 	}
-	topicEntity, err := getTopicEntity(ctx, l.topicName, l.namespace)
+	topicEntity, err := GetTopicEntity(ctx, l.topicName, l.namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get topic: %w", err)
 	}
@@ -267,7 +268,8 @@ func (l *Listener) Close(ctx context.Context) error {
 	return nil
 }
 
-func getTopicEntity(ctx context.Context, topicName string, namespace *servicebus.Namespace) (*servicebus.TopicEntity, error) {
+// GetTopicEntity gets the real time TopicEntity
+func GetTopicEntity(ctx context.Context, topicName string, namespace *servicebus.Namespace) (*servicebus.TopicEntity, error) {
 	tm := namespace.NewTopicManager()
 	return tm.Get(ctx, topicName)
 }


### PR DESCRIPTION
Expose a listener API to get real time TopicEntity. The caller can get the useful information such as the count of active messages in the topic with the TopicEntity.