### PR TITLE
Add traces when handling messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-service-bus-go v0.10.6
 	github.com/Azure/go-autorest/autorest v0.11.6
 	github.com/Azure/go-autorest/autorest/adal v0.9.4
+	github.com/devigned/tab v0.1.1
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.10.2
 	github.com/stretchr/testify v1.6.1

--- a/message/abandon.go
+++ b/message/abandon.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/devigned/tab"
+	"github.com/devigned/tab" // same way as service-bus to log errors
 )
 
 // Abandon stops processing the message and releases the lock on it.
@@ -20,7 +20,7 @@ func (a *abandon) Do(ctx context.Context, _ Handler, message *servicebus.Message
 	defer span.End()
 
 	if err := message.Abandon(ctx); err != nil {
-		tab.For(ctx).Debug(err.Error())
+		tab.For(ctx).Error(err)
 
 		// the processing will terminate and the lock on the message will be released after messageLockDuration
 	}

--- a/message/abandon.go
+++ b/message/abandon.go
@@ -20,7 +20,7 @@ func (a *abandon) Do(ctx context.Context, _ Handler, message *servicebus.Message
 	defer span.End()
 
 	if err := message.Abandon(ctx); err != nil {
-		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
+		tab.For(ctx).Debug(err.Error())
 
 		// the processing will terminate and the lock on the message will be released after messageLockDuration
 	}

--- a/message/abandon.go
+++ b/message/abandon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/devigned/tab"
 )
 
 // Abandon stops processing the message and releases the lock on it.
@@ -15,8 +16,12 @@ type abandon struct {
 }
 
 func (a *abandon) Do(ctx context.Context, _ Handler, message *servicebus.Message) Handler {
+	ctx, span := startSpanFromMessageAndContext(ctx, "go-shuttle.abandon.Do", message)
+	defer span.End()
+
 	if err := message.Abandon(ctx); err != nil {
-		// trace the failure to abandon the message.
+		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
+
 		// the processing will terminate and the lock on the message will be released after messageLockDuration
 	}
 	return done()

--- a/message/complete.go
+++ b/message/complete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/devigned/tab"
 )
 
 // Complete will notify Azure Service Bus that the message was successfully handled and should be deleted from the queue
@@ -15,7 +16,11 @@ type complete struct {
 }
 
 func (a *complete) Do(ctx context.Context, _ Handler, message *servicebus.Message) Handler {
+	ctx, span := startSpanFromMessageAndContext(ctx, "go-shuttle.complete.Do", message)
+	defer span.End()
+
 	if err := message.Complete(ctx); err != nil {
+		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
 		return Error(err)
 	}
 	return done()

--- a/message/complete.go
+++ b/message/complete.go
@@ -20,7 +20,7 @@ func (a *complete) Do(ctx context.Context, _ Handler, message *servicebus.Messag
 	defer span.End()
 
 	if err := message.Complete(ctx); err != nil {
-		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
+		tab.For(ctx).Debug(err.Error())
 		return Error(err)
 	}
 	return done()

--- a/message/complete.go
+++ b/message/complete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/devigned/tab"
+	"github.com/devigned/tab" // same way as service-bus to log errors
 )
 
 // Complete will notify Azure Service Bus that the message was successfully handled and should be deleted from the queue
@@ -20,7 +20,7 @@ func (a *complete) Do(ctx context.Context, _ Handler, message *servicebus.Messag
 	defer span.End()
 
 	if err := message.Complete(ctx); err != nil {
-		tab.For(ctx).Debug(err.Error())
+		tab.For(ctx).Error(err)
 		return Error(err)
 	}
 	return done()

--- a/message/error.go
+++ b/message/error.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/devigned/tab"
 )
 
 // Error is a wrapper around Abandon() that allows to trace the error before abandoning the message
@@ -19,10 +18,6 @@ type errorHandler struct {
 func (a *errorHandler) Do(ctx context.Context, _ Handler, msg *servicebus.Message) Handler {
 	ctx, span := startSpanFromMessageAndContext(ctx, "go-shuttle.errorHandler.Do", msg)
 	defer span.End()
-
-	if a.err != nil {
-		tab.For(ctx).Debug(a.err.Error())
-	}
 
 	return Abandon()
 }

--- a/message/error.go
+++ b/message/error.go
@@ -20,7 +20,9 @@ func (a *errorHandler) Do(ctx context.Context, _ Handler, msg *servicebus.Messag
 	ctx, span := startSpanFromMessageAndContext(ctx, "go-shuttle.errorHandler.Do", msg)
 	defer span.End()
 
-	span.AddAttributes(tab.StringAttribute("errorDetails", a.err.Error()))
+	if a.err != nil {
+		tab.For(ctx).Debug(a.err.Error())
+	}
 
 	return Abandon()
 }

--- a/message/handler.go
+++ b/message/handler.go
@@ -17,7 +17,7 @@ func (h HandleFunc) Do(ctx context.Context, _ Handler, msg *servicebus.Message) 
 
 	wrapped, err := New(msg)
 	if err != nil {
-		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
+		tab.For(ctx).Debug(err.Error())
 		return Error(err)
 	}
 	return h(ctx, wrapped)

--- a/message/handler.go
+++ b/message/handler.go
@@ -4,19 +4,26 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/devigned/tab"
 )
 
 // HandleFunc is a func to handle the message received from a subscription
 type HandleFunc func(ctx context.Context, message *Message) Handler
 
+// Do wraps a service message and returns a handlers
 func (h HandleFunc) Do(ctx context.Context, _ Handler, msg *servicebus.Message) Handler {
+	ctx, span := startSpanFromMessageAndContext(ctx, "go-shuttle.HandlerFunc.Do", msg)
+	defer span.End()
+
 	wrapped, err := New(msg)
 	if err != nil {
+		span.AddAttributes(tab.StringAttribute("errorDetails", err.Error()))
 		return Error(err)
 	}
 	return h(ctx, wrapped)
 }
 
+// Handler is the interface to handle messages
 type Handler interface {
 	Do(ctx context.Context, orig Handler, message *servicebus.Message) Handler
 }

--- a/message/handler.go
+++ b/message/handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/devigned/tab"
+	"github.com/devigned/tab" // same way as service-bus to log errors
 )
 
 // HandleFunc is a func to handle the message received from a subscription
@@ -17,7 +17,7 @@ func (h HandleFunc) Do(ctx context.Context, _ Handler, msg *servicebus.Message) 
 
 	wrapped, err := New(msg)
 	if err != nil {
-		tab.For(ctx).Debug(err.Error())
+		tab.For(ctx).Error(err)
 		return Error(err)
 	}
 	return h(ctx, wrapped)

--- a/message/message.go
+++ b/message/message.go
@@ -7,11 +7,13 @@ import (
 	servicebus "github.com/Azure/azure-service-bus-go"
 )
 
+// Message is the wrapping type of service bus message with a type
 type Message struct {
 	msg         *servicebus.Message
 	messageType string
 }
 
+// New creates a message, validating type first
 func New(msg *servicebus.Message) (*Message, error) {
 	messageType, ok := msg.UserProperties["type"]
 	if !ok {

--- a/message/tracing.go
+++ b/message/tracing.go
@@ -1,0 +1,24 @@
+package message
+
+import (
+	"context"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/devigned/tab"
+)
+
+func startSpanFromMessageAndContext(ctx context.Context, operationName string, message *servicebus.Message) (context.Context, tab.Spanner) {
+	ctx, span := tab.StartSpan(ctx, operationName)
+	if message != nil {
+		attrs := []tab.Attribute{tab.StringAttribute("id", message.ID),
+			tab.Int64Attribute("deliveryCount", int64(message.DeliveryCount))}
+
+		if message.SystemProperties != nil && message.SystemProperties.SequenceNumber != nil {
+			attrs = append(attrs, tab.Int64Attribute("sequenceNumber", *message.SystemProperties.SequenceNumber))
+		}
+
+		span.AddAttributes(attrs...)
+	}
+
+	return ctx, span
+}

--- a/message/tracing.go
+++ b/message/tracing.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"context"
+	"fmt"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
 	"github.com/devigned/tab"
@@ -18,6 +19,8 @@ func startSpanFromMessageAndContext(ctx context.Context, operationName string, m
 		}
 
 		span.AddAttributes(attrs...)
+	} else {
+		span.Logger().Error(fmt.Errorf("message is nil"))
 	}
 
 	return ctx, span


### PR DESCRIPTION
Message handlers (abandon and complete don't return errors to the clients. Let's trace errors to facilitate troubleshooting.

We'd like to enable trace based on "github.com/devigned/tab", which is same as service bus.