### PR TITLE
Change the way to add fields into spans

### DIFF
--- a/message/abandon.go
+++ b/message/abandon.go
@@ -20,7 +20,7 @@ func (a *abandon) Do(ctx context.Context, _ Handler, message *servicebus.Message
 	defer span.End()
 
 	if err := message.Abandon(ctx); err != nil {
-		tab.For(ctx).Error(err)
+		span.AddAttributes(tab.StringAttribute("eventMessage", err.Error()), tab.StringAttribute("eventLevel", "error"))
 
 		// the processing will terminate and the lock on the message will be released after messageLockDuration
 	}

--- a/message/complete.go
+++ b/message/complete.go
@@ -20,7 +20,7 @@ func (a *complete) Do(ctx context.Context, _ Handler, message *servicebus.Messag
 	defer span.End()
 
 	if err := message.Complete(ctx); err != nil {
-		tab.For(ctx).Error(err)
+		span.AddAttributes(tab.StringAttribute("eventMessage", err.Error()), tab.StringAttribute("eventLevel", "error"))
 		return Error(err)
 	}
 	return done()

--- a/message/handler.go
+++ b/message/handler.go
@@ -17,7 +17,7 @@ func (h HandleFunc) Do(ctx context.Context, _ Handler, msg *servicebus.Message) 
 
 	wrapped, err := New(msg)
 	if err != nil {
-		tab.For(ctx).Error(err)
+		span.AddAttributes(tab.StringAttribute("eventMessage", err.Error()), tab.StringAttribute("eventLevel", "error"))
 		return Error(err)
 	}
 	return h(ctx, wrapped)


### PR DESCRIPTION
It looks like tab.For(ctx).Error doesn't really work to add attributes. Let's use span.AddAttributes explicitly.