### PR TITLE
RetryLater should abandon on a seperate go routine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR pubsub
 COPY . .
 RUN touch .env
 #ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["go", "test", "-v", "./integration", "-run", "TestConnectionString/TestPublishAndListenRetryLater"]
+ENTRYPOINT ["go", "test", "-v", "./integration"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR pubsub
 COPY . .
 RUN touch .env
 #ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["go", "test", "-v", "./integration"]
+ENTRYPOINT ["go", "test", "-v", "./integration", "-run", "TestConnectionString/TestPublishAndListenRetryLater"]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ handler := message.HandlerFunc(func(ctx context.Context, msg *message.Message) m
     return msg.RetryLater(10*time.Minute)
 })
 
+This is currently a delayed abanonded so it can not be longer than the lock duration and effects your dequeue count.
+
 // listen blocks and handle messages from the topic
 err := l.Listen(ctx, handler, topicName)
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ handler := message.HandlerFunc(func(ctx context.Context, msg *message.Message) m
     return msg.RetryLater(10*time.Minute)
 })
 
-This is currently a delayed abanonded so it can not be longer than the lock duration and effects your dequeue count.
+This is currently a delayed abandon so it can not be longer than the lock duration and effects your dequeue count.
 
 // listen blocks and handle messages from the topic
 err := l.Listen(ctx, handler, topicName)

--- a/integration/pubsub_test.go
+++ b/integration/pubsub_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
@@ -401,11 +402,13 @@ func checkResultHandler(publishedMsg string, publishedMsgType string, ch chan<- 
 				return message.Error(errors.New("published message type and received message type are different"))
 			}
 			if publishedMsgType == reflection.GetType(retryLaterEvent{}) {
-				if retryCount > 0 {
+				if retryCount > 2 {
+					fmt.Printf("Completing retryLaterEvent at  %v\n", time.Now())
 					ch <- true
 					return message.Complete()
 				}
 				retryCount++
+				fmt.Printf("Retrying retryLaterEvent at %v\n", time.Now())
 				return message.RetryLater(1 * time.Second)
 			}
 			ch <- true

--- a/internal/servicebus/namespace.go
+++ b/internal/servicebus/namespace.go
@@ -2,6 +2,7 @@ package servicebus
 
 import (
 	"errors"
+	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
 	servicebussdk "github.com/Azure/azure-service-bus-go"
@@ -11,6 +12,8 @@ import (
 
 const (
 	serviceBusResourceURI = "https://servicebus.azure.net/"
+	//cannot be higher than 5 minutes
+	LockDuration = 5 * time.Minute
 )
 
 var errorOption func(h *servicebussdk.Namespace) error

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -131,15 +131,21 @@ func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) M
 	}
 }
 
-//allows listeners to control subscription details for longer lived operations.
-//If you using RetryLater you probably want this
-func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) Option {
+// WithSubscriptionDetails allows listeners to control subscription details for longer lived operations.
+// If you using RetryLater you probably want this. Passing zeros leaves it up to Service bus defaults
+func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) ManagementOption {
 	return func(l *Listener) error {
 		if lock > servicebusinternal.LockDuration {
 			//working on getting service bus to enforce this. Hangs if you go higher. https://github.com/Azure/azure-service-bus-go/pull/202
 			return fmt.Errorf("Lock duration must be <= to %v", servicebusinternal.LockDuration)
 		}
+		if lock < time.Duration(0) {
+			return fmt.Errorf("Lock duration must be positive")
+		}
 		l.lockDuration = lock
+		if maxDelivery < 0 {
+			return fmt.Errorf("Max Deliveries must be positive")
+		}
 		l.maxDeliveryCount = maxDelivery
 		return nil
 	}
@@ -189,7 +195,7 @@ func setSubscriptionEntity(ctx context.Context, l *Listener) error {
 	if l.subscriptionName == "" {
 		l.subscriptionName = defaultSubscriptionName
 	}
-	subscriptionEntity, err := l.getSubscriptionEntity(ctx, l.subscriptionName, l.namespace, l.topicEntity)
+	subscriptionEntity, err := l.getSubscriptionEntity(ctx, l.subscriptionName)
 	if err != nil {
 		return fmt.Errorf("failed to get subscription: %w", err)
 	}
@@ -295,7 +301,7 @@ func (l *Listener) GetActiveMessageCount(ctx context.Context, topicName, subscri
 		return 0, fmt.Errorf("topic name %q doesn't match %q", topicName, l.topicName)
 	}
 
-	subscriptionEntity, err := l.getSubscriptionEntity(ctx, subscriptionName, l.namespace, l.topicEntity)
+	subscriptionEntity, err := l.getSubscriptionEntity(ctx, subscriptionName)
 	if err != nil {
 		return 0, fmt.Errorf("error to get entity of subscription %q of topic %q: %s", subscriptionName, topicName, err)
 	}
@@ -316,10 +322,9 @@ func getTopicEntity(ctx context.Context, topicName string, namespace *servicebus
 
 func (l *Listener) getSubscriptionEntity(
 	ctx context.Context,
-	subscriptionName string,
-	ns *servicebus.Namespace,
-	te *servicebus.TopicEntity) (*servicebus.SubscriptionEntity, error) {
-	subscriptionManager, err := ns.NewSubscriptionManager(te.Name)
+	subscriptionName string) (*servicebus.SubscriptionEntity, error) {
+
+	subscriptionManager, err := l.namespace.NewSubscriptionManager(l.topicEntity.Name)
 	if err != nil {
 		return nil, fmt.Errorf("creating subscription manager failed: %w", err)
 	}

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -338,8 +338,13 @@ func (l *Listener) ensureSubscription(ctx context.Context, sm *servicebus.Subscr
 		return subEntity, nil
 	}
 	mutateSericeDetails := func(s *servicebus.SubscriptionDescription) error {
-		s.MaxDeliveryCount = &l.maxDeliveryCount
-		return servicebus.SubscriptionWithLockDuration(&l.lockDuration)(s)
+		if l.maxDeliveryCount != 0 {
+			s.MaxDeliveryCount = &l.maxDeliveryCount
+		}
+		if l.lockDuration > time.Duration(0) {
+			return servicebus.SubscriptionWithLockDuration(&l.lockDuration)(s)
+		}
+		return nil
 	}
 	return sm.Put(ctx, name, mutateSericeDetails)
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -16,7 +15,6 @@ import (
 
 const (
 	defaultSubscriptionName = "default"
-	LockDuration            = 5 * time.Minute //Need to reference from retry later.
 )
 
 // Listener is a struct to contain service bus entities relevant to subscribing to a publisher topic
@@ -327,8 +325,7 @@ func ensureSubscription(ctx context.Context, sm *servicebus.SubscriptionManager,
 		s.MaxDeliveryCount = &maxDeliveryCount //whats our biggest agentpool? this is 5 * 500 minutes
 		return nil
 	}
-
-	duration := LockDuration
+	duration := servicebusinternal.LockDuration
 	return sm.Put(ctx, name, servicebus.SubscriptionWithLockDuration(&duration), increaseMaxDelivery)
 }
 

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -338,7 +338,7 @@ func (l *Listener) ensureSubscription(ctx context.Context, sm *servicebus.Subscr
 		return subEntity, nil
 	}
 	mutateSericeDetails := func(s *servicebus.SubscriptionDescription) error {
-		if l.maxDeliveryCount != 0 {
+		if l.maxDeliveryCount > 0 {
 			s.MaxDeliveryCount = &l.maxDeliveryCount
 		}
 		if l.lockDuration > time.Duration(0) {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -15,6 +16,7 @@ import (
 
 const (
 	defaultSubscriptionName = "default"
+	LockDuration            = 5 * time.Minute //Need to reference from retry later.
 )
 
 // Listener is a struct to contain service bus entities relevant to subscribing to a publisher topic
@@ -320,8 +322,8 @@ func ensureSubscription(ctx context.Context, sm *servicebus.SubscriptionManager,
 	if err == nil {
 		return subEntity, nil
 	}
-
-	return sm.Put(ctx, name)
+	duration := LockDuration
+	return sm.Put(ctx, name, servicebus.SubscriptionWithLockDuration(&duration))
 }
 
 func ensureFilterRule(

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -120,7 +120,7 @@ func WithSubscriptionName(name string) ManagementOption {
 	}
 }
 
-// WithFilterDescriber configures the filters on th56e subscription
+// WithFilterDescriber configures the filters on the subscription
 func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) ManagementOption {
 	return func(l *Listener) error {
 		if len(filterName) == 0 || filter == nil {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -131,7 +131,7 @@ func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) M
 	}
 }
 
-//allos listeners to control subscription details for longer lived operations.
+//allows listeners to control subscription details for longer lived operations.
 //If you using RetryLater you probably want this
 func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) Option {
 	return func(l *Listener) error {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -322,8 +322,14 @@ func ensureSubscription(ctx context.Context, sm *servicebus.SubscriptionManager,
 	if err == nil {
 		return subEntity, nil
 	}
+	increaseMaxDelivery := func(s *servicebus.SubscriptionDescription) error {
+		var maxDeliveryCount int32 = 500
+		s.MaxDeliveryCount = &maxDeliveryCount //whats our biggest agentpool? this is 5 * 500 minutes
+		return nil
+	}
+
 	duration := LockDuration
-	return sm.Put(ctx, name, servicebus.SubscriptionWithLockDuration(&duration))
+	return sm.Put(ctx, name, servicebus.SubscriptionWithLockDuration(&duration), increaseMaxDelivery)
 }
 
 func ensureFilterRule(

--- a/message/retrylater.go
+++ b/message/retrylater.go
@@ -8,8 +8,9 @@ import (
 	"github.com/devigned/tab"
 )
 
-// RetryLater waits for the given duration before retrying the processing of the message.
-// This happens in memory and does not impact servicebus message max retry limit
+// RetryLater waits for the given duration before abanoning.
+// Consider examining/increasing your LockDuration/MaxDeliveryCount before using.
+// Can't retryly later longer than the lock duration (which has a max of 5 minutes)
 func RetryLater(retryAfter time.Duration) Handler {
 	return &retryLaterHandler{
 		retryAfter: retryAfter,

--- a/message/retrylater.go
+++ b/message/retrylater.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
@@ -22,11 +23,17 @@ type retryLaterHandler struct {
 func (r *retryLaterHandler) Do(ctx context.Context, orig Handler, message *servicebus.Message) Handler {
 	go func() {
 		select {
+		//TODO this can go past lock duration pretty easily
+		//Ideally we'd also timeout at dequeue time + lockdurtaion - 1 second but don't have access to dequeue time
+		//Maybe we can use context.WithTimeout when we recieve the message?
 		case <-ctx.Done():
+			//listener should cancel before lock duration which is the longest we can ask for retry later
+			fmt.Printf("messsage context canceled\n")
 			return
-		case <-time.After(r.retryAfter): //or min LockDuration?
+		case <-time.After(r.retryAfter):
+			fmt.Printf("Abandoning messsage %v\n", time.Now())
 			Abandon().Do(ctx, orig, message)
 		}
 	}()
-	return done()
+	return done() //if we stick with abanon for retry we don't need to pass and return handlers
 }

--- a/message/retrylater.go
+++ b/message/retrylater.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
@@ -24,10 +23,10 @@ func (r *retryLaterHandler) Do(ctx context.Context, orig Handler, message *servi
 	go func() {
 		select {
 		case <-ctx.Done():
-			return Error(fmt.Errorf("aborting retrylater for message. abandoning meddage %s: %w", message.ID, ctx.Err()))
-		case <-time.After(r.retryAfter):
-			return orig
+			return
+		case <-time.After(r.retryAfter): //or min LockDuration?
+			Abandon().Do(ctx, orig, message)
 		}
-	}
-	
+	}()
+	return done()
 }

--- a/message/retrylater.go
+++ b/message/retrylater.go
@@ -21,10 +21,13 @@ type retryLaterHandler struct {
 }
 
 func (r *retryLaterHandler) Do(ctx context.Context, orig Handler, message *servicebus.Message) Handler {
-	select {
-	case <-ctx.Done():
-		return Error(fmt.Errorf("aborting retrylater for message. abandoning meddage %s: %w", message.ID, ctx.Err()))
-	case <-time.After(r.retryAfter):
-		return orig
+	go func() {
+		select {
+		case <-ctx.Done():
+			return Error(fmt.Errorf("aborting retrylater for message. abandoning meddage %s: %w", message.ID, ctx.Err()))
+		case <-time.After(r.retryAfter):
+			return orig
+		}
 	}
+	
 }

--- a/message/retrylater.go
+++ b/message/retrylater.go
@@ -10,7 +10,7 @@ import (
 
 // RetryLater waits for the given duration before abanoning.
 // Consider examining/increasing your LockDuration/MaxDeliveryCount before using.
-// Can't retryly later longer than the lock duration (which has a max of 5 minutes)
+// Undefined behavior if RetryLater is passed a duration that puts the message handling past the lock duration (which has a max of 5 minutes)
 func RetryLater(retryAfter time.Duration) Handler {
 	return &retryLaterHandler{
 		retryAfter: retryAfter,


### PR DESCRIPTION
Right now retry later is broken because it will 
1) Block other messages from coming in
2) Block till after lock duration which means completes error  and messages don't finish

