### PR TITLE
chore: split options out from main publisher/listener files

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -7,10 +7,7 @@ import (
 	"time"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-shuttle/handlers"
-	"github.com/Azure/go-shuttle/internal/aad"
-	servicebusinternal "github.com/Azure/go-shuttle/internal/servicebus"
 	"github.com/Azure/go-shuttle/message"
 )
 
@@ -49,111 +46,6 @@ func (l *Listener) Namespace() *servicebus.Namespace {
 	return l.namespace
 }
 
-// ManagementOption provides structure for configuring a new Listener
-type ManagementOption func(l *Listener) error
-
-// Option provides structure for configuring when starting to listen to a specified topic
-type Option func(l *Listener) error
-
-// WithConnectionString configures a listener with the information provided in a Service Bus connection string
-func WithConnectionString(connStr string) ManagementOption {
-	return func(l *Listener) error {
-		if connStr == "" {
-			return errors.New("no Service Bus connection string provided")
-		}
-		ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(connStr))
-		if err != nil {
-			return err
-		}
-		l.namespace = ns
-		return nil
-	}
-}
-
-// WithManagedIdentityClientID configures a listener with the attached managed identity and the Service bus resource name
-func WithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID string) ManagementOption {
-	return func(l *Listener) error {
-		if serviceBusNamespaceName == "" {
-			return errors.New("no Service Bus namespace provided")
-		}
-		ns, err := servicebus.NewNamespace(servicebusinternal.NamespaceWithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID))
-		if err != nil {
-			return err
-		}
-		l.namespace = ns
-		return nil
-	}
-}
-
-// WithToken configures a listener with a AAD token
-func WithToken(serviceBusNamespaceName string, spt *adal.ServicePrincipalToken) ManagementOption {
-	return func(l *Listener) error {
-		if spt == nil {
-			return errors.New("cannot provide a nil token")
-		}
-		ns, err := servicebus.NewNamespace(servicebusinternal.NamespaceWithTokenProvider(serviceBusNamespaceName, aad.AsJWTTokenProvider(spt)))
-		if err != nil {
-			return err
-		}
-		l.namespace = ns
-		return nil
-	}
-}
-
-// WithManagedIdentityResourceID configures a listener with the attached managed identity and the Service bus resource name
-func WithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID string) ManagementOption {
-	return func(l *Listener) error {
-		if serviceBusNamespaceName == "" {
-			return errors.New("no Service Bus namespace provided")
-		}
-		ns, err := servicebus.NewNamespace(servicebusinternal.NamespaceWithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID))
-		if err != nil {
-			return err
-		}
-		l.namespace = ns
-		return nil
-	}
-}
-
-// WithSubscriptionName configures the subscription name of the subscription to listen to
-func WithSubscriptionName(name string) ManagementOption {
-	return func(l *Listener) error {
-		l.subscriptionName = name
-		return nil
-	}
-}
-
-// WithFilterDescriber configures the filters on the subscription
-func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) ManagementOption {
-	return func(l *Listener) error {
-		if len(filterName) == 0 || filter == nil {
-			return errors.New("filter name or filter cannot be zero value")
-		}
-		l.filterDefinitions = append(l.filterDefinitions, &filterDefinition{filterName, filter})
-		return nil
-	}
-}
-
-// WithSubscriptionDetails allows listeners to control subscription details for longer lived operations.
-// If you using RetryLater you probably want this. Passing zeros leaves it up to Service bus defaults
-func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) ManagementOption {
-	return func(l *Listener) error {
-		if lock > servicebusinternal.LockDuration {
-			//working on getting service bus to enforce this. Hangs if you go higher. https://github.com/Azure/azure-service-bus-go/pull/202
-			return fmt.Errorf("Lock duration must be <= to %v", servicebusinternal.LockDuration)
-		}
-		if lock < time.Duration(0) {
-			return fmt.Errorf("Lock duration must be positive")
-		}
-		l.lockDuration = lock
-		if maxDelivery < 0 {
-			return fmt.Errorf("max deliveries must be positive")
-		}
-		l.maxDeliveryCount = maxDelivery
-		return nil
-	}
-}
-
 // WithPrefetchCount the receiver to quietly acquires more messages, up to the PrefetchCount limit. A single Receive call to the ServiceBus api
 // therefore acquires several messages for immediate consumption that is returned as soon as available.
 // Please be aware of the consequences : https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-prefetch#if-it-is-faster-why-is-prefetch-not-the-default-option
@@ -175,16 +67,6 @@ func WithMaxConcurrency(concurrency int) Option {
 			return fmt.Errorf("concurrency must be greater than 0")
 		}
 		l.maxConcurrency = &concurrency
-		return nil
-	}
-}
-
-func WithMessageLockAutoRenewal(interval time.Duration) Option {
-	return func(l *Listener) error {
-		if interval < time.Duration(0) {
-			return fmt.Errorf("renewal interval must be positive")
-		}
-		l.lockRenewalInterval = &interval
 		return nil
 	}
 }
@@ -286,7 +168,6 @@ func (l *Listener) Listen(ctx context.Context, handler message.Handler, topicNam
 	}()
 
 	// Generate new subscription client
-	// TODO: Add servicebus.SubscriptionWithPrefetchCount(prefetch count) option and expose the setting via the listener
 	sub, err := topic.NewSubscription(l.subscriptionEntity.Name)
 	if err != nil {
 		return fmt.Errorf("failed to create new subscription %s: %w", l.subscriptionEntity.Name, err)
@@ -312,6 +193,7 @@ func (l *Listener) Listen(ctx context.Context, handler message.Handler, topicNam
 			)))
 	l.listenerHandle = listenerHandle
 	<-listenerHandle.Done()
+
 	if err := subReceiver.Close(ctx); err != nil {
 		return fmt.Errorf("error shutting down service bus subscription. %w", err)
 	}
@@ -324,6 +206,7 @@ func (l *Listener) Close(ctx context.Context) error {
 		return errors.New("no active listener. cannot close")
 	}
 	if err := l.listenerHandle.Close(ctx); err != nil {
+		l.listenerHandle = nil
 		return fmt.Errorf("error shutting down service bus subscription. %w", err)
 	}
 	return nil

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -46,31 +46,6 @@ func (l *Listener) Namespace() *servicebus.Namespace {
 	return l.namespace
 }
 
-// WithPrefetchCount the receiver to quietly acquires more messages, up to the PrefetchCount limit. A single Receive call to the ServiceBus api
-// therefore acquires several messages for immediate consumption that is returned as soon as available.
-// Please be aware of the consequences : https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-prefetch#if-it-is-faster-why-is-prefetch-not-the-default-option
-func WithPrefetchCount(prefetch uint32) Option {
-	return func(l *Listener) error {
-		if prefetch < 1 {
-			return fmt.Errorf("prefetch count value cannot be less than 1")
-		}
-		if prefetch >= 1 {
-			l.prefetchCount = &prefetch
-		}
-		return nil
-	}
-}
-
-func WithMaxConcurrency(concurrency int) Option {
-	return func(l *Listener) error {
-		if concurrency < 0 {
-			return fmt.Errorf("concurrency must be greater than 0")
-		}
-		l.maxConcurrency = &concurrency
-		return nil
-	}
-}
-
 type filterDefinition struct {
 	Name   string
 	Filter servicebus.FilterDescriber

--- a/listener/options.go
+++ b/listener/options.go
@@ -1,0 +1,127 @@
+package listener
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-shuttle/internal/aad"
+	sbinternal "github.com/Azure/go-shuttle/internal/servicebus"
+)
+
+// Option provides structure for configuring when starting to listen to a specified topic
+type Option func(l *Listener) error
+
+func WithMessageLockAutoRenewal(interval time.Duration) Option {
+	return func(l *Listener) error {
+		if interval < time.Duration(0) {
+			return fmt.Errorf("renewal interval must be positive")
+		}
+		l.lockRenewalInterval = &interval
+		return nil
+	}
+}
+
+// ManagementOption provides structure for configuring a new Listener
+type ManagementOption func(l *Listener) error
+
+// WithConnectionString configures a listener with the information provided in a Service Bus connection string
+func WithConnectionString(connStr string) ManagementOption {
+	return func(l *Listener) error {
+		if connStr == "" {
+			return errors.New("no Service Bus connection string provided")
+		}
+		ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(connStr))
+		if err != nil {
+			return err
+		}
+		l.namespace = ns
+		return nil
+	}
+}
+
+// WithManagedIdentityClientID configures a listener with the attached managed identity and the Service bus resource name
+func WithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID string) ManagementOption {
+	return func(l *Listener) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		ns, err := servicebus.NewNamespace(sbinternal.NamespaceWithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID))
+		if err != nil {
+			return err
+		}
+		l.namespace = ns
+		return nil
+	}
+}
+
+// WithToken configures a listener with a AAD token
+func WithToken(serviceBusNamespaceName string, spt *adal.ServicePrincipalToken) ManagementOption {
+	return func(l *Listener) error {
+		if spt == nil {
+			return errors.New("cannot provide a nil token")
+		}
+		ns, err := servicebus.NewNamespace(sbinternal.NamespaceWithTokenProvider(serviceBusNamespaceName, aad.AsJWTTokenProvider(spt)))
+		if err != nil {
+			return err
+		}
+		l.namespace = ns
+		return nil
+	}
+}
+
+// WithManagedIdentityResourceID configures a listener with the attached managed identity and the Service bus resource name
+func WithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID string) ManagementOption {
+	return func(l *Listener) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		ns, err := servicebus.NewNamespace(sbinternal.NamespaceWithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID))
+		if err != nil {
+			return err
+		}
+		l.namespace = ns
+		return nil
+	}
+}
+
+// WithSubscriptionName configures the subscription name of the subscription to listen to
+func WithSubscriptionName(name string) ManagementOption {
+	return func(l *Listener) error {
+		l.subscriptionName = name
+		return nil
+	}
+}
+
+// WithFilterDescriber configures the filters on the subscription
+func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) ManagementOption {
+	return func(l *Listener) error {
+		if len(filterName) == 0 || filter == nil {
+			return errors.New("filter name or filter cannot be zero value")
+		}
+		l.filterDefinitions = append(l.filterDefinitions, &filterDefinition{filterName, filter})
+		return nil
+	}
+}
+
+// WithSubscriptionDetails allows listeners to control subscription details for longer lived operations.
+// If you using RetryLater you probably want this. Passing zeros leaves it up to Service bus defaults
+func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) ManagementOption {
+	return func(l *Listener) error {
+		if lock > sbinternal.LockDuration {
+			// working on getting service bus to enforce this. Hangs if you go higher. https://github.com/Azure/azure-service-bus-go/pull/202
+			return fmt.Errorf("lock duration must be <= to %v", sbinternal.LockDuration)
+		}
+		if lock < time.Duration(0) {
+			return fmt.Errorf("lock duration must be positive")
+		}
+		l.lockDuration = lock
+		if maxDelivery < 0 {
+			return fmt.Errorf("max Deliveries must be positive")
+		}
+		l.maxDeliveryCount = maxDelivery
+		return nil
+	}
+}

--- a/listener/options.go
+++ b/listener/options.go
@@ -125,3 +125,28 @@ func WithSubscriptionDetails(lock time.Duration, maxDelivery int32) ManagementOp
 		return nil
 	}
 }
+
+// WithPrefetchCount the receiver to quietly acquires more messages, up to the PrefetchCount limit. A single Receive call to the ServiceBus api
+// therefore acquires several messages for immediate consumption that is returned as soon as available.
+// Please be aware of the consequences : https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-prefetch#if-it-is-faster-why-is-prefetch-not-the-default-option
+func WithPrefetchCount(prefetch uint32) Option {
+	return func(l *Listener) error {
+		if prefetch < 1 {
+			return fmt.Errorf("prefetch count value cannot be less than 1")
+		}
+		if prefetch >= 1 {
+			l.prefetchCount = &prefetch
+		}
+		return nil
+	}
+}
+
+func WithMaxConcurrency(concurrency int) Option {
+	return func(l *Listener) error {
+		if concurrency < 0 {
+			return fmt.Errorf("concurrency must be greater than 0")
+		}
+		l.maxConcurrency = &concurrency
+		return nil
+	}
+}

--- a/publisher/options.go
+++ b/publisher/options.go
@@ -1,0 +1,129 @@
+package publisher
+
+import (
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-shuttle/internal/aad"
+	servicebus2 "github.com/Azure/go-shuttle/internal/servicebus"
+)
+
+// ManagementOption provides structure for configuring a new Publisher
+type ManagementOption func(p *Publisher) error
+
+// Option provides structure for configuring when starting to publish to a specified topic
+type Option func(msg *servicebus.Message) error
+
+// WithConnectionString configures a publisher with the information provided in a Service Bus connection string
+func WithConnectionString(connStr string) ManagementOption {
+	return func(p *Publisher) error {
+		if connStr == "" {
+			return errors.New("no Service Bus connection string provided")
+		}
+		ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(connStr))
+		if err != nil {
+			return err
+		}
+		p.namespace = ns
+		return nil
+	}
+}
+
+// WithManagedIdentityResourceID configures a publisher with the attached managed identity and the Service bus resource name
+func WithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID string) ManagementOption {
+	return func(p *Publisher) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		ns, err := servicebus.NewNamespace(servicebus2.NamespaceWithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID))
+		if err != nil {
+			return err
+		}
+		p.namespace = ns
+		return nil
+	}
+}
+
+// WithManagedIdentityClientID configures a publisher with the attached managed identity and the Service bus resource name
+func WithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID string) ManagementOption {
+	return func(p *Publisher) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		ns, err := servicebus.NewNamespace(servicebus2.NamespaceWithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID))
+		if err != nil {
+			return err
+		}
+		p.namespace = ns
+		return nil
+	}
+}
+
+func WithToken(serviceBusNamespaceName string, spt *adal.ServicePrincipalToken) ManagementOption {
+	return func(p *Publisher) error {
+		if spt == nil {
+			return errors.New("cannot provide a nil token")
+		}
+		ns, err := servicebus.NewNamespace(servicebus2.NamespaceWithTokenProvider(serviceBusNamespaceName, aad.AsJWTTokenProvider(spt)))
+		if err != nil {
+			return err
+		}
+		p.namespace = ns
+		return nil
+	}
+}
+
+// SetDefaultHeader adds a header to every message published using the value specified from the message body
+func SetDefaultHeader(headerName, msgKey string) ManagementOption {
+	return func(p *Publisher) error {
+		if p.headers == nil {
+			p.headers = make(map[string]string)
+		}
+		p.headers[headerName] = msgKey
+		return nil
+	}
+}
+
+// SetDuplicateDetection guarantees that the topic will have exactly-once delivery over a user-defined span of time.
+// Defaults to 30 seconds with a maximum of 7 days
+func WithDuplicateDetection(window *time.Duration) ManagementOption {
+	return func(p *Publisher) error {
+		p.topicManagementOptions = append(p.topicManagementOptions, servicebus.TopicWithDuplicateDetection(window))
+		return nil
+	}
+}
+
+// SetMessageDelay schedules a message in the future
+func SetMessageDelay(delay time.Duration) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign message delay")
+		}
+		msg.ScheduleAt(time.Now().Add(delay))
+		return nil
+	}
+}
+
+// SetMessageID sets the messageID of the message. Used for duplication detection
+func SetMessageID(messageID string) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign message ID")
+		}
+		msg.ID = messageID
+		return nil
+	}
+}
+
+// SetCorrelationID sets the SetCorrelationID of the message.
+func SetCorrelationID(correlationID string) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign correlation ID")
+		}
+		msg.CorrelationID = correlationID
+		return nil
+	}
+}


### PR DESCRIPTION
`listener.go` and `publisher.go` are becoming too large.
splitting the options out to keep them leaner