### PR TITLE
Improving safety of Handler creation

### DIFF
--- a/handlers/concurrent.go
+++ b/handlers/concurrent.go
@@ -2,30 +2,34 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
 )
 
-var _ servicebus.Handler = (*Concurrent)(nil)
+var _ servicebus.Handler = (*concurrent)(nil)
 
 // Concurrent is a servicebus handler starts concurrent workers processing messages
 // maxConcurrency configures the maximum of concurrent workers started by the handler
-type Concurrent struct {
+type concurrent struct {
 	next              servicebus.Handler
 	concurrencyTokens chan bool
 }
 
-func NewConcurrent(maxConcurrency int, next servicebus.Handler) *Concurrent {
-	return &Concurrent{
+func NewConcurrent(maxConcurrency int, next servicebus.Handler) servicebus.Handler {
+	if maxConcurrency < 1 {
+		panic(fmt.Sprintf("maxConcurrency must be >= 1, but was %d", maxConcurrency))
+	}
+	if next == nil {
+		panic(NextHandlerNilError.Error())
+	}
+	return &concurrent{
 		next:              next,
 		concurrencyTokens: make(chan bool, maxConcurrency),
 	}
 }
 
-func (c *Concurrent) Handle(ctx context.Context, msg *servicebus.Message) error {
-	if c.next == nil {
-		return NextHandlerNilError
-	}
+func (c *concurrent) Handle(ctx context.Context, msg *servicebus.Message) error {
 	c.concurrencyTokens <- true
 	go func() {
 		defer func() { <-c.concurrencyTokens }()

--- a/handlers/shuttleadapter.go
+++ b/handlers/shuttleadapter.go
@@ -8,25 +8,25 @@ import (
 	"github.com/devigned/tab"
 )
 
-var _ servicebus.Handler = (*ShuttleAdapter)(nil)
+var _ servicebus.Handler = (*shuttleAdapter)(nil)
 
 // ShuttleAdapter wraps a go-shuttle message.Handler in a servicebus.Handler.
 // It allows the consumer to write go-shuttle handler func
 // that uses the go-shuttle semantic and message disposition API
-type ShuttleAdapter struct {
+type shuttleAdapter struct {
 	next message.Handler
 }
 
-func NewShuttleAdapter(next message.Handler) *ShuttleAdapter {
-	return &ShuttleAdapter{next: next}
+func NewShuttleAdapter(next message.Handler) servicebus.Handler {
+	if next == nil {
+		panic(NextHandlerNilError.Error())
+	}
+	return &shuttleAdapter{next: next}
 }
 
-func (c *ShuttleAdapter) Handle(ctx context.Context, msg *servicebus.Message) error {
+func (c *shuttleAdapter) Handle(ctx context.Context, msg *servicebus.Message) error {
 	ctx, s := tab.StartSpan(ctx, "go-shuttle.Listener.HandlerFunc")
 	defer s.End()
-	if c.next == nil {
-		return NextHandlerNilError
-	}
 	currentHandler := c.next
 	for !message.IsDone(currentHandler) {
 		currentHandler = currentHandler.Do(ctx, c.next, msg)


### PR DESCRIPTION
I noticed that if a concurrent handler was being used that the error returned by any child handler of the concurrent handler would be ignored as there was no way to pass the error out of the go-routine and back to the parent function.

So, in this PR I am switching to panic on creation + making struct creation have to flow through the constructor in order to make sure that any error would be caught within the creation step and panic