### PR TITLE
Add Explicit Subscription Flags for AZ CLI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ push-test-image:
 test-aci: clean-aci scripts/containergroup.yaml
 	containerId=$$(az container create --file scripts/containergroup.yaml \
 	--resource-group ${TEST_RESOURCE_GROUP} \
+	--subscription ${AZURE_SUBSCRIPTION_ID} \
 	--verbose \
 	--query id -o tsv) ;\
 	az container logs --ids $${containerId} --follow
@@ -28,6 +29,7 @@ test-aci: clean-aci scripts/containergroup.yaml
 shell-aci: clean-aci
 	az container create --file scripts/containergroup.yaml \
 	--resource-group ${TEST_RESOURCE_GROUP} \
+	--subscription ${AZURE_SUBSCRIPTION_ID} \
 	--command-line "/bin/bash"; \
 	az container attach --name "pubsubtester" --resource-group "${TEST_RESOURCE_GROUP}"
 
@@ -39,6 +41,7 @@ clean-aci:
 	az container delete \
 	--resource-group ${TEST_RESOURCE_GROUP} \
 	--name pubsubtester \
+	--subscription ${AZURE_SUBSCRIPTION_ID} \
 	--yes
 
 integration: build-test-image push-test-image test-aci

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test-setup:
 
 .PHONY: cleanup-test-setup
 cleanup-test-setup:
-	az group delete --name ${TEST_RESOURCE_GROUP}
+	az group delete --name ${TEST_RESOURCE_GROUP} --subscription ${AZURE_SUBSCRIPTION_ID}
 
 build-test-image:
 	docker build -t ${IMAGE} .

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -6,11 +6,13 @@ echo "creating RG"
 az group create \
 --name ${TEST_RESOURCE_GROUP} \
 --location ${TEST_LOCATION} \
+--subscription ${AZURE_SUBSCRIPTION_ID} \
 -o none
 
 echo "create managed identity"
 MANAGED_IDENTITY_CLIENT_ID=$(az identity create \
 --name "${SERVICEBUS_NAMESPACE_NAME}_id" \
+--subscription ${AZURE_SUBSCRIPTION_ID} \
 -g ${TEST_RESOURCE_GROUP} \
 --query clientId \
 -o tsv)
@@ -22,20 +24,22 @@ az acr create \
 --name ${REGISTRY_NAME} \
 --location ${TEST_LOCATION} \
 --resource-group ${TEST_RESOURCE_GROUP} \
+--subscription ${AZURE_SUBSCRIPTION_ID} \
 --admin-enabled true \
 --sku Basic \
 -o none
 
 echo "getting ACR credentials"
-REGISTRY=$(az acr show --name ${REGISTRY_NAME} --query loginServer -o tsv)
-REGISTRY_USER=$(az acr credential show --name ${REGISTRY_NAME} --query username -o tsv)
-REGISTRY_PASSWORD=$(az acr credential show --name ${REGISTRY_NAME} --query "passwords | [0].value" -o tsv)
+REGISTRY=$(az acr show --name ${REGISTRY_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --query loginServer  -o tsv)
+REGISTRY_USER=$(az acr credential show --name ${REGISTRY_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --query username -o tsv)
+REGISTRY_PASSWORD=$(az acr credential show --name ${REGISTRY_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --query "passwords | [0].value" -o tsv)
 
 echo "create ServiceBus namespace"
 SERVICEBUS_ID=$(az servicebus namespace create \
 --name ${SERVICEBUS_NAMESPACE_NAME} \
 -l ${TEST_LOCATION} \
 -g ${TEST_RESOURCE_GROUP} \
+--subscription ${AZURE_SUBSCRIPTION_ID} \
 --sku premium \
 --query id \
 -o tsv)
@@ -43,6 +47,7 @@ SERVICEBUS_ID=$(az servicebus namespace create \
 SERVICEBUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys list \
 --resource-group ${TEST_RESOURCE_GROUP} \
 --namespace-name ${SERVICEBUS_NAMESPACE_NAME} \
+--subscription ${AZURE_SUBSCRIPTION_ID} \
 --name "RootManageSharedAccessKey" \
 --query primaryConnectionString \
 -o tsv)


### PR DESCRIPTION
In the case where the `default az-cli subscription id` != `$AZURE_SUBSCRIPTION_ID`, the current `test-setup` and `integration` scripts will fail.

`MANAGED_IDENTITY_RESOURCE_ID` in `test-setup.sh` will be constructed incorrectly due to the mismatch.

This PR fix just propagates the `AZURE_SUBSCRIPTION_ID` to all `az-cli` calls as an explicit `--subscription` flag.