### PR TITLE
feat: add event type filter option helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE folders and files
+.idea
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/integration/pubsub_test.go
+++ b/integration/pubsub_test.go
@@ -63,14 +63,14 @@ func (suite *serviceBusSuite) TestPublishAndListenUsingTypeFilter() {
 	// listener with wrong event type. not getting the event
 	failListener, err := listener.New(suite.listenerAuthOption,
 		listener.WithSubscriptionName("subEventTypeFilterFail"),
-		listener.WithEventTypeFilter(&notTestEvent{}))
+		listener.WithTypeFilter(&notTestEvent{}))
 	suite.NoError(err)
 	suite.typeFilterTest(pub, failListener, false)
 
 	// update subscription to filter on correct event type. succeeds receiving event
 	successListener, err := listener.New(suite.listenerAuthOption,
 		listener.WithSubscriptionName("subEventTypeFilter"),
-		listener.WithEventTypeFilter(&testEvent{}))
+		listener.WithTypeFilter(&testEvent{}))
 	suite.typeFilterTest(pub, successListener, true)
 }
 

--- a/listener/options.go
+++ b/listener/options.go
@@ -107,9 +107,9 @@ func WithFilterDescriber(filterName string, filter servicebus.FilterDescriber) M
 	}
 }
 
-// WithEventTypeFilter will subscribe to event of the go type provided.
+// WithTypeFilter will subscribe to event of the go type provided.
 // It uses the `type` property automatically to messages published via go-shuttle.
-func WithEventTypeFilter(event interface{}) ManagementOption {
+func WithTypeFilter(event interface{}) ManagementOption {
 	typeName := getTypeName(event)
 	return WithFilterDescriber(fmt.Sprintf("tf_%s", typeName), servicebus.SQLFilter{Expression: fmt.Sprintf("type LIKE '%s'", typeName)})
 }


### PR DESCRIPTION
this allows the consumer to define a type filter on the subscription by providing an instance of the event : 

```golang
l, err := listener.New(suite.listenerAuthOption,
		listener.WithSubscriptionName("subEventTypeFilter"),
		listener.WithTypeFilter(&testEvent{}))
```

`listener.WithTypeFilter(&testEvent{}))` 

is a shortcut for : 

`listener.WithFilterDescriber("testFilter", servicebus.SQLFilter{Expression: "type LIKE 'testEvent'"}))`

It allows to optimize the filter to avoid the SQLFilter in the future