### PR TITLE
add publisher recovery on network error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR pubsub
 COPY . .
 RUN touch .env
 #ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["go", "test", "--tags=integration", "-v", "./integration"]
+ENTRYPOINT ["go", "test", "--tags=integration,debug", "-v", "./integration"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
     image: ${IMAGE}
     # entrypoint: ["ls"]
     #    command: ["-run", "TestConnectionString/TestPublishAndListenNotRenewingLock", "-tags", "debug"]
-    # command: ["-run", "TestConnectionString/TestPublishAndListenConcurrentPrefetch", "-tags", "debug"]
-    command: ["-run", "TestConnectionString/TestCompleteCloseToLockExpiry", "-tags", "debug"]
+    command: ["-timeout", "6h" , "-run", "TestConnectionString/TestSoakPub"]
+    # command: ["-run", "TestConnectionString/TestCompleteCloseToLockExpiry", "-tags", "debug"]
     env_file:
     - .env
     environment:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/Azure/azure-amqp-common-go/v3 v3.1.0
 	github.com/Azure/azure-service-bus-go v0.10.12-0.20210225175612-bb0d9d0bf8ba
-	github.com/Azure/go-amqp v0.13.5
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect

--- a/integration/publisher_test.go
+++ b/integration/publisher_test.go
@@ -4,8 +4,12 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"testing"
+	"time"
 
 	"github.com/Azure/go-shuttle/publisher"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestCreatePublisherWithNewTopic tests the creation of a publisher for a new topic
@@ -37,4 +41,99 @@ func (suite *serviceBusSuite) TestCreatePublisherUsingExistingTopic() {
 		_, err := tm.Get(context.Background(), suite.TopicName)
 		suite.NoError(err)
 	}
+}
+
+// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+func (suite *serviceBusSuite) TestPublishAfterIdle() {
+	type idlenessTest struct {
+		topicName string
+		sleepTime time.Duration
+	}
+
+	tests := []idlenessTest{
+		{topicName: "idle6min", sleepTime: 5 * time.Minute},
+	}
+	for _, idleTestCase := range tests {
+		tc := idleTestCase
+		suite.T().Run(suite.T().Name()+tc.topicName, func(test *testing.T) {
+			test.Parallel()
+			err := testIdleness(suite.publisherAuthOption, tc.topicName, tc.sleepTime)
+			assert.NoError(test, err)
+		})
+	}
+}
+
+// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+func (suite *serviceBusSuite) TestSoakPub() {
+	suite.T().Parallel()
+	type idlenessTest struct {
+		topicName string
+		sleepTime time.Duration
+	}
+
+	tests := []idlenessTest{
+		{topicName: "soakinterval2sec", sleepTime: 2 * time.Second},
+		{topicName: "soakinterval30sec", sleepTime: 30 * time.Second},
+		{topicName: "soakinterval5min", sleepTime: 2 * time.Minute},
+	}
+
+	soakTime := 10 * time.Minute
+	deadline, _ := context.WithTimeout(context.Background(), soakTime)
+
+	for _, soak := range tests {
+		tc := soak
+		suite.T().Run(suite.T().Name()+tc.topicName, func(test *testing.T) {
+			test.Parallel()
+			err := testSoak(deadline, suite.publisherAuthOption, tc.topicName, tc.sleepTime)
+			assert.NoError(test, err)
+			suite.FailNow(err.Error())
+		})
+	}
+}
+
+func testSoak(ctx context.Context, authOptions publisher.ManagementOption, topicName string, idleTime time.Duration) error {
+	p, err := publisher.New(context.Background(), topicName, authOptions)
+	if err != nil {
+		return err
+	}
+	ok := true
+	// stop on deadline
+	go func() {
+		<-ctx.Done()
+		ok = false
+	}()
+
+	iteration := 0
+	for ok {
+		iteration++
+		err := p.Publish(context.TODO(), &testEvent{
+			ID:    iteration,
+			Key:   "key",
+			Value: "value",
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println("[", topicName, "] published event ", iteration)
+		time.Sleep(idleTime)
+	}
+	return p.Close(context.TODO())
+}
+
+func testIdleness(authOptions publisher.ManagementOption, topicName string, idleTime time.Duration) error {
+	p, err := publisher.New(context.Background(), topicName, authOptions)
+	if err != nil {
+		return err
+	}
+	p.Publish(context.TODO(), &testEvent{
+		ID:    1,
+		Key:   "key1",
+		Value: "value1",
+	})
+	time.Sleep(idleTime)
+	return p.Publish(context.TODO(), &testEvent{
+		ID:    2,
+		Key:   "key2",
+		Value: "value2",
+	})
 }

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -105,7 +105,7 @@ func (p *Publisher) tryRecoverTopic(ctx context.Context, sendError error) error 
 	if errors.As(sendError, &neterr) && (!neterr.Temporary() || neterr.Timeout()) {
 		// re-create topic/sender
 		if err := p.initTopic(p.topic.Name); err != nil {
-			return fmt.Errorf("failed to init topic on recovery: %w")
+			return fmt.Errorf("failed to init topic on recovery: %w", err)
 		}
 		return nil
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -3,7 +3,9 @@ package publisher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	common "github.com/Azure/azure-amqp-common-go/v3"
@@ -44,12 +46,9 @@ func New(ctx context.Context, topicName string, opts ...ManagementOption) (*Publ
 	if err != nil {
 		return nil, fmt.Errorf("failed to get topic: %w", err)
 	}
-	topic, err := publisher.namespace.NewTopic(topicEntity.Name)
-	if err != nil {
+	if err = publisher.initTopic(topicEntity.Name); err != nil {
 		return nil, fmt.Errorf("failed to create new topic %s: %w", topicEntity.Name, err)
 	}
-
-	publisher.topic = topic
 	return publisher, nil
 }
 
@@ -72,7 +71,6 @@ func (p *Publisher) Publish(ctx context.Context, msg interface{}, opts ...Option
 		}
 	}
 
-	// now apply publishing options
 	for _, opt := range opts {
 		err := opt(sbMsg)
 		if err != nil {
@@ -80,12 +78,38 @@ func (p *Publisher) Publish(ctx context.Context, msg interface{}, opts ...Option
 		}
 	}
 
-	// finally, send
 	err = p.topic.Send(ctx, sbMsg)
-	if err != nil {
-		return fmt.Errorf("failed to send message to topic %s: %w", p.topic.Name, err)
+	if err == nil {
+		return nil
+	}
+	// recover + retry
+	if recErr := p.tryRecoverTopic(ctx, err); recErr != nil {
+		return fmt.Errorf("failed to recover topic on send failure %s. recoveryError : %w, sendError: %s", p.topic.Name, recErr, err)
+	}
+	if err = p.topic.Send(ctx, sbMsg); err != nil {
+		return fmt.Errorf("failed to send message to topic %s after recovery: %w", p.topic.Name, err)
 	}
 	return nil
+}
+
+func (p *Publisher) Close(ctx context.Context) error {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.Close")
+	defer s.End()
+	return p.topic.Close(ctx)
+}
+
+func (p *Publisher) tryRecoverTopic(ctx context.Context, sendError error) error {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.tryRecoverTopic", tab.StringAttribute("error", sendError.Error()))
+	defer s.End()
+	var neterr net.Error
+	if errors.As(sendError, &neterr) && (!neterr.Temporary() || neterr.Timeout()) {
+		// re-create topic/sender
+		if err := p.initTopic(p.topic.Name); err != nil {
+			return fmt.Errorf("failed to init topic on recovery: %w")
+		}
+		return nil
+	}
+	return fmt.Errorf("error is not identified as recoverable: %w", sendError)
 }
 
 func ensureTopic(ctx context.Context, name string, namespace *servicebus.Namespace, opts ...servicebus.TopicManagementOption) (*servicebus.TopicEntity, error) {
@@ -113,4 +137,13 @@ func ensureTopic(ctx context.Context, name string, namespace *servicebus.Namespa
 		return nil, err
 	}
 	return entity.(*servicebus.TopicEntity), nil
+}
+
+func (p *Publisher) initTopic(name string) error {
+	topic, err := p.namespace.NewTopic(name)
+	if err != nil {
+		return fmt.Errorf("failed to create new topic %s: %w", name, err)
+	}
+	p.topic = topic
+	return nil
 }


### PR DESCRIPTION
When the underlying tcp connection is lost, the next publish call fails with a network error. The connection will never be re-established by AMQP, leaving the publisher in a truly broken state. the only available recourse for the application code is to re-create the publisher.

This PR adds recovery code in the `Send` func to rebuild the underlying topic and retry to send the message when we meet a network error that is not temporary, or when it is recognized as a timeout (happens when tcp has been closed).
