### PR TITLE
Queue Publisher Implementation

### DIFF
--- a/integration/concurrentcreate_topic_test.go
+++ b/integration/concurrentcreate_topic_test.go
@@ -6,16 +6,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/go-shuttle/publisher/topic"
 	"sync"
 	"time"
 
 	"github.com/Azure/go-shuttle/listener"
 	"github.com/Azure/go-shuttle/message"
-	"github.com/Azure/go-shuttle/publisher"
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *serviceBusSuite) TestCreatePublisherConcurrently() {
+func (suite *serviceBusTopicSuite) TestCreatePublisherConcurrently() {
 	suite.T().Parallel()
 	topicName := "newTopic" + suite.TagID
 	w := sync.WaitGroup{}
@@ -23,7 +23,7 @@ func (suite *serviceBusSuite) TestCreatePublisherConcurrently() {
 		w.Add(1)
 		go func(it int) {
 			defer w.Done()
-			_, err := publisher.New(context.Background(), topicName, suite.publisherAuthOption)
+			_, err := topic.New(context.Background(), topicName, suite.publisherAuthOption)
 			if !assert.NoError(suite.T(), err, "failed on iteration %d", it) {
 				suite.FailNow(err.Error())
 			}
@@ -42,10 +42,10 @@ func (suite *serviceBusSuite) TestCreatePublisherConcurrently() {
 	suite.NoError(err)
 }
 
-func (suite *serviceBusSuite) TestCreateListenersConcurrently() {
+func (suite *serviceBusTopicSuite) TestCreateListenersConcurrently() {
 	suite.T().Parallel()
 	topicName := "newTopic" + suite.TagID
-	_, err := publisher.New(context.Background(), topicName, suite.publisherAuthOption)
+	_, err := topic.New(context.Background(), topicName, suite.publisherAuthOption)
 	assert.NoError(suite.T(), err)
 	w := sync.WaitGroup{}
 	lctx, cancel := context.WithTimeout(context.TODO(), 20*time.Second)

--- a/integration/issue_topic_test.go
+++ b/integration/issue_topic_test.go
@@ -10,17 +10,17 @@ import (
 
 	"github.com/Azure/go-shuttle/listener"
 	"github.com/Azure/go-shuttle/message"
-	"github.com/Azure/go-shuttle/publisher"
+	tp "github.com/Azure/go-shuttle/publisher/topic"
 	"github.com/devigned/tab"
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *serviceBusSuite) TestCompleteCloseToLockExpiryWithPrefetch() {
+func (suite *serviceBusTopicSuite) TestCompleteCloseToLockExpiryWithPrefetch() {
 	suite.T().Parallel()
 	// creating a separate topic that was not created at the beginning of the test suite
 	// note that this topic will also be deleted at the tear down of the suite due to the tagID at the end of the topic name
 	topic := suite.Prefix + "issue189" + suite.TagID
-	pub, err := publisher.New(context.Background(), topic, suite.publisherAuthOption)
+	pub, err := tp.New(context.Background(), topic, suite.publisherAuthOption)
 	suite.NoError(err)
 	l, err := listener.New(
 		suite.listenerAuthOption,
@@ -43,12 +43,12 @@ func (suite *serviceBusSuite) TestCompleteCloseToLockExpiryWithPrefetch() {
 	}, event)
 }
 
-func (suite *serviceBusSuite) TestCompleteCloseToLockExpiryNoConcurrency() {
+func (suite *serviceBusTopicSuite) TestCompleteCloseToLockExpiryNoConcurrency() {
 	suite.T().Parallel()
 	// creating a separate topic that was not created at the beginning of the test suite
 	// note that this topic will also be deleted at the tear down of the suite due to the tagID at the end of the topic name
 	topic := suite.Prefix + "issue189" + suite.TagID
-	pub, err := publisher.New(context.Background(), topic, suite.publisherAuthOption)
+	pub, err := tp.New(context.Background(), topic, suite.publisherAuthOption)
 	suite.NoError(err)
 	l, err := listener.New(
 		suite.listenerAuthOption,
@@ -71,7 +71,7 @@ func (suite *serviceBusSuite) TestCompleteCloseToLockExpiryNoConcurrency() {
 }
 
 // https://github.com/Azure/azure-service-bus-go/issues/189
-func (suite *serviceBusSuite) verifyHalfOfLockDurationComplete(testConfig publishReceiveTest, event *testEvent) {
+func (suite *serviceBusTopicSuite) verifyHalfOfLockDurationComplete(testConfig publishReceiveTest, event *testEvent) {
 	parentCtx := context.Background()
 	returnedHandler := make(chan message.Handler, *testConfig.publishCount)
 	handler := message.HandleFunc(func(ctx context.Context, msg *message.Message) message.Handler {

--- a/integration/listener_test.go
+++ b/integration/listener_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 // TestCreateNewListenerFromConnectionString tests the creation of a listener with a connection string
-func (suite *serviceBusSuite) TestCreateNewListener() {
+func (suite *serviceBusTopicSuite) TestCreateNewListener() {
 	_, err := listener.New(suite.listenerAuthOption)
 	suite.NoError(err)
 }
 
-func (suite *serviceBusSuite) TestListenWithDefault() {
+func (suite *serviceBusTopicSuite) TestListenWithDefault() {
 	listener, err := listener.New(suite.listenerAuthOption)
 	if suite.NoError(err) {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -36,7 +36,7 @@ func (suite *serviceBusSuite) TestListenWithDefault() {
 	}
 }
 
-func (suite *serviceBusSuite) TestListenWithCustomSubscription() {
+func (suite *serviceBusTopicSuite) TestListenWithCustomSubscription() {
 	listener, err := listener.New(
 		suite.listenerAuthOption,
 		listener.WithSubscriptionName("subName"))
@@ -56,7 +56,7 @@ func (suite *serviceBusSuite) TestListenWithCustomSubscription() {
 	}
 }
 
-func (suite *serviceBusSuite) TestListenWithCustomFilter() {
+func (suite *serviceBusTopicSuite) TestListenWithCustomFilter() {
 	createRule, err := listener.New(
 		suite.listenerAuthOption,
 		listener.WithSubscriptionName("default"),
@@ -85,7 +85,7 @@ func (suite *serviceBusSuite) TestListenWithCustomFilter() {
 }
 
 // startListenAndCheckForFilter starts the listener and makes sure that the correct rules were created
-func (suite *serviceBusSuite) startListenAndCheckForFilter(
+func (suite *serviceBusTopicSuite) startListenAndCheckForFilter(
 	l *listener.Listener,
 	filterName string,
 	filter servicebus.FilterDescriber) {
@@ -118,7 +118,7 @@ func contextCanceledError(err error) bool {
 		strings.Contains(err.Error(), "context canceled")
 }
 
-func (suite *serviceBusSuite) checkRule(ns *servicebus.Namespace, subName, filterName string, filter servicebus.FilterDescriber) (bool, error) {
+func (suite *serviceBusTopicSuite) checkRule(ns *servicebus.Namespace, subName, filterName string, filter servicebus.FilterDescriber) (bool, error) {
 	sm, err := ns.NewSubscriptionManager(suite.TopicName)
 	if err != nil {
 		return false, err

--- a/integration/publisher_queue_test.go
+++ b/integration/publisher_queue_test.go
@@ -1,0 +1,144 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/go-shuttle/publisher/queue"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCreatePublisherWithNewTopic tests the creation of a publisher for a new topic
+func (suite *serviceBusQueueSuite) TestCreatePublisherUsingNewQueue() {
+	suite.T().Parallel()
+	queueName := "newQueue" + suite.TagID
+	_, err := queue.New(context.Background(), queueName, suite.publisherAuthOption)
+	if suite.NoError(err) {
+		// make sure that topic exists
+		ns := suite.GetNewNamespace()
+		tm := ns.NewQueueManager()
+		_, err := tm.Get(context.Background(), queueName)
+		suite.NoError(err)
+
+		// delete new topic
+		err = tm.Delete(context.Background(), queueName)
+		suite.NoError(err)
+	}
+}
+
+// TestCreatePublisherWithExistingQueue tests the creation of a publisher for an existing queue and a connection string
+func (suite *serviceBusQueueSuite) TestCreatePublisherUsingExistingQueue() {
+	// this assumes that the testTopic was created at the start of the test suite
+	_, err := queue.New(context.Background(), suite.QueueName, suite.publisherAuthOption)
+	if suite.NoError(err) {
+		// make sure that topic exists
+		ns := suite.GetNewNamespace()
+		tm := ns.NewQueueManager()
+		_, err := tm.Get(context.Background(), suite.QueueName)
+		suite.NoError(err)
+	}
+}
+
+// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+func (suite *serviceBusQueueSuite) TestPublishAfterIdle() {
+	type idlenessTest struct {
+		queueName string
+		sleepTime time.Duration
+	}
+
+	tests := []idlenessTest{
+		{queueName: "idle6min", sleepTime: 5 * time.Minute},
+	}
+	for _, idleTestCase := range tests {
+		tc := idleTestCase
+		suite.T().Run(suite.T().Name()+tc.queueName, func(test *testing.T) {
+			test.Parallel()
+			err := testQueueIdleness(suite.publisherAuthOption, tc.queueName, tc.sleepTime)
+			assert.NoError(test, err)
+		})
+	}
+}
+
+// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+func (suite *serviceBusQueueSuite) TestSoakPub() {
+	suite.T().Parallel()
+	type idlenessTest struct {
+		queueName string
+		sleepTime time.Duration
+	}
+
+	tests := []idlenessTest{
+		{queueName: "soakinterval2sec", sleepTime: 2 * time.Second},
+		{queueName: "soakinterval30sec", sleepTime: 30 * time.Second},
+		{queueName: "soakinterval5min", sleepTime: 2 * time.Minute},
+	}
+
+	soakTime := 10 * time.Minute
+	deadline, _ := context.WithTimeout(context.Background(), soakTime)
+
+	for _, soak := range tests {
+		tc := soak
+		suite.T().Run(suite.T().Name()+tc.queueName, func(test *testing.T) {
+			test.Parallel()
+			err := testQueueSoak(deadline, suite.publisherAuthOption, tc.queueName, tc.sleepTime)
+			if !assert.NoError(test, err) {
+				suite.FailNow(err.Error())
+			}
+		})
+	}
+}
+
+func testQueueSoak(ctx context.Context, authOptions queue.ManagementOption, queueName string, idleTime time.Duration) error {
+	p, err := queue.New(context.Background(), queueName, authOptions)
+	if err != nil {
+		return err
+	}
+	ok := true
+	// stop on deadline
+	go func() {
+		<-ctx.Done()
+		ok = false
+	}()
+
+	iteration := 0
+	for ok {
+		iteration++
+		err := p.Publish(context.TODO(), &testEvent{
+			ID:    iteration,
+			Key:   "key",
+			Value: "value",
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println("[", queueName, "] published event ", iteration)
+		select {
+		case <-time.After(idleTime):
+		case <-ctx.Done():
+			continue
+		}
+	}
+	return p.Close(context.TODO())
+}
+
+func testQueueIdleness(authOptions queue.ManagementOption, queueName string, idleTime time.Duration) error {
+	p, err := queue.New(context.Background(), queueName, authOptions)
+	if err != nil {
+		return err
+	}
+	p.Publish(context.TODO(), &testEvent{
+		ID:    1,
+		Key:   "key1",
+		Value: "value1",
+	})
+	time.Sleep(idleTime)
+	return p.Publish(context.TODO(), &testEvent{
+		ID:    2,
+		Key:   "key2",
+		Value: "value2",
+	})
+}

--- a/integration/publisher_queue_test.go
+++ b/integration/publisher_queue_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestCreatePublisherWithNewTopic tests the creation of a publisher for a new topic
+// TestCreatePublisherWithNewQueue tests the creation of a publisher for a new queue
 func (suite *serviceBusQueueSuite) TestCreatePublisherUsingNewQueue() {
 	suite.T().Parallel()
 	queueName := "newQueue" + suite.TagID
 	_, err := queue.New(context.Background(), queueName, suite.publisherAuthOption)
 	if suite.NoError(err) {
-		// make sure that topic exists
+		// make sure that queue exists
 		ns := suite.GetNewNamespace()
 		tm := ns.NewQueueManager()
 		_, err := tm.Get(context.Background(), queueName)
 		suite.NoError(err)
 
-		// delete new topic
+		// delete new queue
 		err = tm.Delete(context.Background(), queueName)
 		suite.NoError(err)
 	}
@@ -32,10 +32,10 @@ func (suite *serviceBusQueueSuite) TestCreatePublisherUsingNewQueue() {
 
 // TestCreatePublisherWithExistingQueue tests the creation of a publisher for an existing queue and a connection string
 func (suite *serviceBusQueueSuite) TestCreatePublisherUsingExistingQueue() {
-	// this assumes that the testTopic was created at the start of the test suite
+	// this assumes that the testQueue was created at the start of the test suite
 	_, err := queue.New(context.Background(), suite.QueueName, suite.publisherAuthOption)
 	if suite.NoError(err) {
-		// make sure that topic exists
+		// make sure that queue exists
 		ns := suite.GetNewNamespace()
 		tm := ns.NewQueueManager()
 		_, err := tm.Get(context.Background(), suite.QueueName)
@@ -43,7 +43,7 @@ func (suite *serviceBusQueueSuite) TestCreatePublisherUsingExistingQueue() {
 	}
 }
 
-// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+// TestPublishAfterIdle tests the creation of a publisher for an existing queue and a connection string
 func (suite *serviceBusQueueSuite) TestPublishAfterIdle() {
 	type idlenessTest struct {
 		queueName string
@@ -63,7 +63,7 @@ func (suite *serviceBusQueueSuite) TestPublishAfterIdle() {
 	}
 }
 
-// TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
+// TestPublishAfterIdle tests the creation of a publisher for an existing queue and a connection string
 func (suite *serviceBusQueueSuite) TestSoakPub() {
 	suite.T().Parallel()
 	type idlenessTest struct {

--- a/integration/publisher_topic_test.go
+++ b/integration/publisher_topic_test.go
@@ -5,18 +5,18 @@ package integration
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/go-shuttle/publisher/topic"
 	"testing"
 	"time"
 
-	"github.com/Azure/go-shuttle/publisher"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestCreatePublisherWithNewTopic tests the creation of a publisher for a new topic
-func (suite *serviceBusSuite) TestCreatePublisherUsingNewTopic() {
+func (suite *serviceBusTopicSuite) TestCreatePublisherUsingNewTopic() {
 	suite.T().Parallel()
 	topicName := "newTopic" + suite.TagID
-	_, err := publisher.New(context.Background(), topicName, suite.publisherAuthOption)
+	_, err := topic.New(context.Background(), topicName, suite.publisherAuthOption)
 	if suite.NoError(err) {
 		// make sure that topic exists
 		ns := suite.GetNewNamespace()
@@ -31,9 +31,9 @@ func (suite *serviceBusSuite) TestCreatePublisherUsingNewTopic() {
 }
 
 // TestCreatePublisherWithExistingTopic tests the creation of a publisher for an existing topic and a connection string
-func (suite *serviceBusSuite) TestCreatePublisherUsingExistingTopic() {
+func (suite *serviceBusTopicSuite) TestCreatePublisherUsingExistingTopic() {
 	// this assumes that the testTopic was created at the start of the test suite
-	_, err := publisher.New(context.Background(), suite.TopicName, suite.publisherAuthOption)
+	_, err := topic.New(context.Background(), suite.TopicName, suite.publisherAuthOption)
 	if suite.NoError(err) {
 		// make sure that topic exists
 		ns := suite.GetNewNamespace()
@@ -44,7 +44,7 @@ func (suite *serviceBusSuite) TestCreatePublisherUsingExistingTopic() {
 }
 
 // TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
-func (suite *serviceBusSuite) TestPublishAfterIdle() {
+func (suite *serviceBusTopicSuite) TestPublishAfterIdle() {
 	type idlenessTest struct {
 		topicName string
 		sleepTime time.Duration
@@ -64,7 +64,7 @@ func (suite *serviceBusSuite) TestPublishAfterIdle() {
 }
 
 // TestPublishAfterIdle tests the creation of a publisher for an existing topic and a connection string
-func (suite *serviceBusSuite) TestSoakPub() {
+func (suite *serviceBusTopicSuite) TestSoakPub() {
 	suite.T().Parallel()
 	type idlenessTest struct {
 		topicName string
@@ -92,8 +92,8 @@ func (suite *serviceBusSuite) TestSoakPub() {
 	}
 }
 
-func testSoak(ctx context.Context, authOptions publisher.ManagementOption, topicName string, idleTime time.Duration) error {
-	p, err := publisher.New(context.Background(), topicName, authOptions)
+func testSoak(ctx context.Context, authOptions topic.ManagementOption, topicName string, idleTime time.Duration) error {
+	p, err := topic.New(context.Background(), topicName, authOptions)
 	if err != nil {
 		return err
 	}
@@ -125,8 +125,8 @@ func testSoak(ctx context.Context, authOptions publisher.ManagementOption, topic
 	return p.Close(context.TODO())
 }
 
-func testIdleness(authOptions publisher.ManagementOption, topicName string, idleTime time.Duration) error {
-	p, err := publisher.New(context.Background(), topicName, authOptions)
+func testIdleness(authOptions topic.ManagementOption, topicName string, idleTime time.Duration) error {
+	p, err := topic.New(context.Background(), topicName, authOptions)
 	if err != nil {
 		return err
 	}

--- a/integration/suite_queue_test.go
+++ b/integration/suite_queue_test.go
@@ -94,7 +94,7 @@ func withQueuePublisherManagedIdentityResourceID() queue.ManagementOption {
 func (suite *serviceBusQueueSuite) SetupSuite() {
 	suite.BaseSuite.SetupSuite()
 	suite.QueueName = suite.Prefix + testQueueName + suite.TagID
-	_, err := suite.EnsureTopic(context.Background(), suite.QueueName)
+	_, err := suite.EnsureQueue(context.Background(), suite.QueueName)
 	if err != nil {
 		suite.T().Fatal(err)
 	}

--- a/integration/suite_queue_test.go
+++ b/integration/suite_queue_test.go
@@ -1,0 +1,102 @@
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-shuttle/internal/test"
+	"github.com/Azure/go-shuttle/publisher/queue"
+	"github.com/stretchr/testify/suite"
+	"os"
+	"testing"
+)
+
+type serviceBusQueueSuite struct {
+	test.BaseSuite
+	Prefix              string
+	QueueName           string
+	Publisher           queue.Publisher
+	publisherAuthOption queue.ManagementOption
+}
+
+const testQueueName = "testQueue"
+
+func TestQueueConnectionString(t *testing.T) {
+	t.Parallel()
+	connectionStringSuite := &serviceBusQueueSuite{
+		Prefix:              "conn-",
+		publisherAuthOption: withQueuePublisherConnectionString(),
+	}
+	suite.Run(t, connectionStringSuite)
+}
+
+func TestQueueClientId(t *testing.T) {
+	t.Parallel()
+	clientIdSuite := &serviceBusQueueSuite{
+		Prefix:              "cid-",
+		publisherAuthOption: withQueuePublisherManagedIdentityClientID(),
+	}
+	suite.Run(t, clientIdSuite)
+}
+
+func TestQueueResourceID(t *testing.T) {
+	t.Parallel()
+	resourceIdSuite := &serviceBusQueueSuite{
+		Prefix:              "rid-",
+		publisherAuthOption: withQueuePublisherManagedIdentityResourceID(),
+	}
+	suite.Run(t, resourceIdSuite)
+}
+
+func withQueuePublisherConnectionString() queue.ManagementOption {
+	connStr := os.Getenv("SERVICEBUS_CONNECTION_STRING") // `Endpoint=sb://XXXX.servicebus.windows.net/;SharedAccessKeyName=XXXX;SharedAccessKey=XXXX`
+	if connStr == "" {
+		panic("environment variable SERVICEBUS_CONNECTION_STRING was not set")
+	}
+
+	return queue.WithConnectionString(connStr)
+}
+
+func withQueuePublisherManagedIdentityClientID() queue.ManagementOption {
+	serviceBusNamespaceName := os.Getenv("SERVICEBUS_NAMESPACE_NAME") // `Endpoint=sb://XXXX.servicebus.windows.net/;SharedAccessKeyName=XXXX;SharedAccessKey=XXXX`
+	if serviceBusNamespaceName == "" {
+		panic("environment variable SERVICEBUS_NAMESPACE_NAME was not set")
+	}
+
+	// if managedIdentityClientID is empty then library will assume system assigned managed identity
+	managedIdentityClientID := os.Getenv("MANAGED_IDENTITY_CLIENT_ID")
+
+	token, err := adalToken(managedIdentityClientID, adal.NewServicePrincipalTokenFromMSIWithUserAssignedID)
+	if err != nil {
+		panic(err)
+	}
+	return queue.WithToken(serviceBusNamespaceName, token)
+}
+
+func withQueuePublisherManagedIdentityResourceID() queue.ManagementOption {
+	serviceBusNamespaceName := os.Getenv("SERVICEBUS_NAMESPACE_NAME") // `Endpoint=sb://XXXX.servicebus.windows.net/;SharedAccessKeyName=XXXX;SharedAccessKey=XXXX`
+	if serviceBusNamespaceName == "" {
+		panic("environment variable SERVICEBUS_NAMESPACE_NAME was not set")
+	}
+
+	managedIdentityResourceID := os.Getenv("MANAGED_IDENTITY_RESOURCE_ID")
+	if managedIdentityResourceID == "" {
+		panic("environment variable MANAGED_IDENTITY_RESOURCE_ID was not set")
+	}
+	token, err := adalToken(managedIdentityResourceID, adal.NewServicePrincipalTokenFromMSIWithIdentityResourceID)
+	if err != nil {
+		panic(err)
+	}
+	return queue.WithToken(serviceBusNamespaceName, token)
+}
+
+func (suite *serviceBusQueueSuite) SetupSuite() {
+	suite.BaseSuite.SetupSuite()
+	suite.QueueName = suite.Prefix + testQueueName + suite.TagID
+	_, err := suite.EnsureTopic(context.Background(), suite.QueueName)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+}
+

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -141,6 +141,19 @@ func (suite *BaseSuite) EnsureTopic(ctx context.Context, name string) (*serviceb
 	return tm.Put(ctx, name)
 }
 
+// EnsureQueue checks if the queue exists and creates one if it doesn't
+func (suite *BaseSuite) EnsureQueue(ctx context.Context, name string) (*servicebus.QueueEntity, error) {
+	ns := suite.GetNewNamespace()
+	qm := ns.NewQueueManager()
+
+	qe, err := qm.Get(ctx, name)
+	if err == nil {
+		return qe, nil
+	}
+
+	return qm.Put(ctx, name)
+}
+
 // randomString generates a random string with prefix
 func randomString(prefix string, length int) string {
 	b := make([]rune, length)

--- a/publisher/queue/options.go
+++ b/publisher/queue/options.go
@@ -1,4 +1,4 @@
-package publisher
+package queue
 
 import (
 	"errors"
@@ -13,7 +13,7 @@ import (
 // ManagementOption provides structure for configuring a new Publisher
 type ManagementOption func(p *Publisher) error
 
-// Option provides structure for configuring when starting to publish to a specified topic
+// Option provides structure for configuring when starting to publish to a specified queue
 type Option func(msg *servicebus.Message) error
 
 // WithConnectionString configures a publisher with the information provided in a Service Bus connection string
@@ -82,7 +82,7 @@ func SetDefaultHeader(headerName, msgKey string) ManagementOption {
 // Defaults to 30 seconds with a maximum of 7 days
 func WithDuplicateDetection(window *time.Duration) ManagementOption {
 	return func(p *Publisher) error {
-		p.topicManagementOptions = append(p.topicManagementOptions, servicebus.TopicWithDuplicateDetection(window))
+		p.queueManagementOptions = append(p.queueManagementOptions, servicebus.QueueEntityWithDuplicateDetection(window))
 		return nil
 	}
 }

--- a/publisher/queue/options_test.go
+++ b/publisher/queue/options_test.go
@@ -1,0 +1,23 @@
+package queue
+
+import (
+	"testing"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithEnvironmentName(t *testing.T) {
+	v := assert.New(t)
+	pub := &Publisher{namespace: &servicebus.Namespace{}}
+	expectedEnv := azure.Environment{
+		Name:                     "test",
+		ServiceBusEndpointSuffix: "testsuffix.com",
+	}
+	azure.SetEnvironment("test", expectedEnv)
+	err := WithEnvironmentName("test")(pub)
+	v.NoError(err)
+	v.Equal(expectedEnv, pub.namespace.Environment)
+	v.Equal(expectedEnv.ServiceBusEndpointSuffix, pub.namespace.Suffix)
+}

--- a/publisher/queue/publisher.go
+++ b/publisher/queue/publisher.go
@@ -1,0 +1,148 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	common "github.com/Azure/azure-amqp-common-go/v3"
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-shuttle/internal/reflection"
+	"github.com/devigned/tab"
+)
+
+// Publisher is a struct to contain service bus entities relevant to publishing to a queue
+type Publisher struct {
+	namespace              *servicebus.Namespace
+	queue                  *servicebus.Queue
+	headers                map[string]string
+	queueManagementOptions []servicebus.QueueManagementOption
+}
+
+func (p *Publisher) Namespace() *servicebus.Namespace {
+	return p.namespace
+}
+
+// New creates a new service bus publisher
+func New(ctx context.Context, queueName string, opts ...ManagementOption) (*Publisher, error) {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.New")
+	defer s.End()
+	ns, err := servicebus.NewNamespace()
+	if err != nil {
+		return nil, err
+	}
+	publisher := &Publisher{namespace: ns}
+	for _, opt := range opts {
+		err := opt(publisher)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	queueEntity, err := ensureQueue(ctx, queueName, publisher.namespace, publisher.queueManagementOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get queue: %w", err)
+	}
+	if err = publisher.initQueue(queueEntity.Name); err != nil {
+		return nil, fmt.Errorf("failed to create new queue %s: %w", queueEntity.Name, err)
+	}
+	return publisher, nil
+}
+
+// Publish publishes to the pre-configured Service Bus queue
+func (p *Publisher) Publish(ctx context.Context, msg interface{}, opts ...Option) error {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.Publish")
+	defer s.End()
+	msgJSON, err := json.Marshal(msg)
+
+	// adding in user properties to enable filtering on listener side
+	sbMsg := servicebus.NewMessageFromString(string(msgJSON))
+	sbMsg.UserProperties = make(map[string]interface{})
+	sbMsg.UserProperties["type"] = reflection.GetType(msg)
+
+	// add in custom headers setup at initialization time
+	for headerName, headerKey := range p.headers {
+		val := reflection.GetReflectionValue(msg, headerKey)
+		if val != nil {
+			sbMsg.UserProperties[headerName] = val
+		}
+	}
+
+	for _, opt := range opts {
+		err := opt(sbMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = p.queue.Send(ctx, sbMsg)
+	if err == nil {
+		return nil
+	}
+	// recover + retry
+	if recErr := p.tryRecoverQueue(ctx, err); recErr != nil {
+		return fmt.Errorf("failed to recover queue on send failure %s. recoveryError : %w, sendError: %s", p.queue.Name, recErr, err)
+	}
+	if err = p.queue.Send(ctx, sbMsg); err != nil {
+		return fmt.Errorf("failed to send message to queue %s after recovery: %w", p.queue.Name, err)
+	}
+	return nil
+}
+
+func (p *Publisher) Close(ctx context.Context) error {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.Close")
+	defer s.End()
+	return p.queue.Close(ctx)
+}
+
+func (p *Publisher) tryRecoverQueue(ctx context.Context, sendError error) error {
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.publisher.tryRecoverQueue", tab.StringAttribute("error", sendError.Error()))
+	defer s.End()
+	var neterr net.Error
+	if errors.As(sendError, &neterr) && (!neterr.Temporary() || neterr.Timeout()) {
+		if err := p.initQueue(p.queue.Name); err != nil {
+			return fmt.Errorf("failed to init queue on recovery: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("error is not identified as recoverable: %w", sendError)
+}
+
+func ensureQueue(ctx context.Context, name string, namespace *servicebus.Namespace, opts ...servicebus.QueueManagementOption) (*servicebus.QueueEntity, error) {
+	attempt := 1
+	qm := namespace.NewQueueManager()
+	ensure := func() (interface{}, error) {
+		ctx, span := tab.StartSpan(ctx, "go-shuttle.publisher.ensureQueue")
+		span.AddAttributes(tab.Int64Attribute("retry.attempt", int64(attempt)))
+		qe, err := qm.Get(ctx, name)
+		if err == nil {
+			return qe, nil
+		}
+		qe, err = qm.Put(ctx, name, opts...)
+		if err != nil {
+			attempt++
+			tab.For(ctx).Error(err)
+			// let all errors be retryable for now. application only hit this once on queue creation.
+			return nil, common.Retryable(err.Error())
+		}
+		return qe, nil
+	}
+	entity, err := common.Retry(5, 1*time.Second, ensure)
+	if err != nil {
+		tab.For(ctx).Error(err)
+		return nil, err
+	}
+	return entity.(*servicebus.QueueEntity), nil
+}
+
+func (p *Publisher) initQueue(name string) error {
+	queue, err := p.namespace.NewQueue(name)
+	if err != nil {
+		return fmt.Errorf("failed to create new queue %s: %w", name, err)
+	}
+	p.queue = queue
+	return nil
+}

--- a/publisher/topic/options.go
+++ b/publisher/topic/options.go
@@ -1,0 +1,121 @@
+package topic
+
+import (
+	"errors"
+	"time"
+
+	"github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-shuttle/internal/aad"
+	sbinternal "github.com/Azure/go-shuttle/internal/servicebus"
+)
+
+// ManagementOption provides structure for configuring a new Publisher
+type ManagementOption func(p *Publisher) error
+
+// Option provides structure for configuring when starting to publish to a specified topic
+type Option func(msg *servicebus.Message) error
+
+// WithConnectionString configures a publisher with the information provided in a Service Bus connection string
+func WithConnectionString(connStr string) ManagementOption {
+	return func(p *Publisher) error {
+		if connStr == "" {
+			return errors.New("no Service Bus connection string provided")
+		}
+		return servicebus.NamespaceWithConnectionString(connStr)(p.namespace)
+	}
+}
+
+// WithEnvironmentName configures the azure environment used to connect to Servicebus. The environment value used is
+// then provided by Azure/go-autorest.
+// ref: https://github.com/Azure/go-autorest/blob/c7f947c0610de1bc279f76e6d453353f95cd1bfa/autorest/azure/environments.go#L34
+func WithEnvironmentName(environmentName string) ManagementOption {
+	return func(p *Publisher) error {
+		if environmentName == "" {
+			return errors.New("cannot use empty environment name")
+		}
+		return servicebus.NamespaceWithAzureEnvironment(p.namespace.Name, environmentName)(p.namespace)
+	}
+}
+
+// WithManagedIdentityResourceID configures a publisher with the attached managed identity and the Service bus resource name
+func WithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID string) ManagementOption {
+	return func(p *Publisher) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		return sbinternal.NamespaceWithManagedIdentityResourceID(serviceBusNamespaceName, managedIdentityResourceID)(p.namespace)
+	}
+}
+
+// WithManagedIdentityClientID configures a publisher with the attached managed identity and the Service bus resource name
+func WithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID string) ManagementOption {
+	return func(p *Publisher) error {
+		if serviceBusNamespaceName == "" {
+			return errors.New("no Service Bus namespace provided")
+		}
+		return sbinternal.NamespaceWithManagedIdentityClientID(serviceBusNamespaceName, managedIdentityClientID)(p.namespace)
+	}
+}
+
+func WithToken(serviceBusNamespaceName string, spt *adal.ServicePrincipalToken) ManagementOption {
+	return func(p *Publisher) error {
+		if spt == nil {
+			return errors.New("cannot provide a nil token")
+		}
+		return sbinternal.NamespaceWithTokenProvider(serviceBusNamespaceName, aad.AsJWTTokenProvider(spt))(p.namespace)
+	}
+}
+
+// SetDefaultHeader adds a header to every message published using the value specified from the message body
+func SetDefaultHeader(headerName, msgKey string) ManagementOption {
+	return func(p *Publisher) error {
+		if p.headers == nil {
+			p.headers = make(map[string]string)
+		}
+		p.headers[headerName] = msgKey
+		return nil
+	}
+}
+
+// SetDuplicateDetection guarantees that the topic will have exactly-once delivery over a user-defined span of time.
+// Defaults to 30 seconds with a maximum of 7 days
+func WithDuplicateDetection(window *time.Duration) ManagementOption {
+	return func(p *Publisher) error {
+		p.topicManagementOptions = append(p.topicManagementOptions, servicebus.TopicWithDuplicateDetection(window))
+		return nil
+	}
+}
+
+// SetMessageDelay schedules a message in the future
+func SetMessageDelay(delay time.Duration) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign message delay")
+		}
+		msg.ScheduleAt(time.Now().Add(delay))
+		return nil
+	}
+}
+
+// SetMessageID sets the messageID of the message. Used for duplication detection
+func SetMessageID(messageID string) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign message ID")
+		}
+		msg.ID = messageID
+		return nil
+	}
+}
+
+// SetCorrelationID sets the SetCorrelationID of the message.
+func SetCorrelationID(correlationID string) Option {
+	return func(msg *servicebus.Message) error {
+		if msg == nil {
+			return errors.New("message is nil. cannot assign correlation ID")
+		}
+		msg.CorrelationID = correlationID
+		return nil
+	}
+}

--- a/publisher/topic/options_test.go
+++ b/publisher/topic/options_test.go
@@ -1,4 +1,4 @@
-package publisher
+package topic
 
 import (
 	"testing"

--- a/publisher/topic/publisher.go
+++ b/publisher/topic/publisher.go
@@ -1,4 +1,4 @@
-package publisher
+package topic
 
 import (
 	"context"


### PR DESCRIPTION
Implementation and refactor to support ServiceBus Queues.

This PR focuses on establishing the pattern for creating a Queue Publisher -- the patterns decided on will follow for the Listener implementation/refactor.