### PR TITLE
Recover from amqp-internal error by recreating connection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,9 @@ services:
     image: ${IMAGE}
     # entrypoint: ["ls"]
     #    command: ["-run", "TestConnectionString/TestPublishAndListenNotRenewingLock", "-tags", "debug"]
-    command: ["-timeout", "6h" , "-run", "TestConnectionString/TestSoakPub"]
+    # command: ["-timeout", "6h" , "-run", "TestConnectionString/TestSoakPub"]
     # command: ["-run", "TestConnectionString/TestCompleteCloseToLockExpiry", "-tags", "debug"]
+    command: ["-run", "TestConnectionString"]
     env_file:
     - .env
     environment:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Azure/azure-amqp-common-go/v3 v3.1.0
 	github.com/Azure/azure-service-bus-go v0.10.12
+	github.com/Azure/go-amqp v0.13.7
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect

--- a/handlers/shuttleadapter.go
+++ b/handlers/shuttleadapter.go
@@ -25,7 +25,7 @@ func NewShuttleAdapter(next message.Handler) servicebus.Handler {
 }
 
 func (c *shuttleAdapter) Handle(ctx context.Context, msg *servicebus.Message) error {
-	ctx, s := tab.StartSpan(ctx, "go-shuttle.Listener.HandlerFunc")
+	ctx, s := tab.StartSpan(ctx, "go-shuttle.listener.shuttleAdapter.Handle")
 	defer s.End()
 	currentHandler := c.next
 	for !message.IsDone(currentHandler) {

--- a/message/error.go
+++ b/message/error.go
@@ -2,8 +2,10 @@ package message
 
 import (
 	"context"
+	"errors"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-amqp"
 	"github.com/Azure/go-shuttle/tracing"
 )
 
@@ -20,6 +22,13 @@ func (h *errorHandler) Do(ctx context.Context, _ Handler, msg *servicebus.Messag
 	ctx, span := tracing.StartSpanFromMessageAndContext(ctx, "go-shuttle.errorHandler.Do", msg)
 	defer span.End()
 	span.Logger().Error(h.err)
+	var amqpErr *amqp.Error
+	if errors.As(h.err, &amqpErr) {
+		span.Logger().Info("error was amqp error. will not attempt to abandon the message")
+		// the processing will terminate and the lock on the message will eventually be released after
+		// the message lock expires on the broker side
+		return done()
+	}
 	return Abandon()
 }
 

--- a/publisher/errorhandling/recovery.go
+++ b/publisher/errorhandling/recovery.go
@@ -19,7 +19,7 @@ import (
 //    SystemTracker:<REDACTED> Topic:<REDACTED>, Timestamp:2021-06-19T23:17:15, Info: map[]
 // }
 func isAmqpInternalError(err error) bool {
-	var amqpErr amqp.Error
+	var amqpErr *amqp.Error
 	return errors.As(err, &amqpErr) &&
 		amqpErr.Condition == amqp.ErrorInternalError &&
 		strings.HasPrefix("the service was unable to process the request", strings.ToLower(amqpErr.Description))

--- a/publisher/errorhandling/recovery.go
+++ b/publisher/errorhandling/recovery.go
@@ -1,0 +1,35 @@
+package errorhandling
+
+import (
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/Azure/go-amqp"
+)
+
+// NOTE: Although the error message says that the operation can be retried, amqp:internal-error has been found to be persistent until we rebuild the connection (i.e: restart the process)
+// sample error :
+// *Error{
+//    Condition: amqp:internal-error,
+//    Description: The service was unable to process the request; please retry the operation.
+//    For more information on exception types and proper exception handling, please refer to http://go.microsoft.com/fwlink/?LinkId=761101
+//    Reference:<REDACTED>,
+//    TrackingId:<REDACTED>,
+//    SystemTracker:<REDACTED> Topic:<REDACTED>, Timestamp:2021-06-19T23:17:15, Info: map[]
+// }
+func isAmqpInternalError(err error) bool {
+	var amqpErr amqp.Error
+	return errors.As(err, &amqpErr) &&
+		amqpErr.Condition == amqp.ErrorInternalError &&
+		strings.HasPrefix("the service was unable to process the request", strings.ToLower(amqpErr.Description))
+}
+
+func isPermanentNetError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && (!netErr.Temporary() || netErr.Timeout())
+}
+
+func IsConnectionDead(err error) bool {
+	return isPermanentNetError(err) || isAmqpInternalError(err)
+}

--- a/publisher/errorhandling/recovery_test.go
+++ b/publisher/errorhandling/recovery_test.go
@@ -1,0 +1,50 @@
+package errorhandling
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/Azure/go-amqp"
+)
+
+type temporaryError struct {
+	message string
+}
+
+func (te temporaryError) Error() string {
+	return te.message
+}
+
+func (te temporaryError) Timeout() bool {
+	return false
+}
+
+func (te temporaryError) Temporary() bool {
+	return true
+}
+
+func TestIsConnectionDead(t *testing.T) {
+	tests := []struct {
+		name       string
+		givenError error
+		want       bool
+	}{
+		{name: "syscall-timeoutError", givenError: syscall.ETIMEDOUT, want: true},
+		{name: "randomError", givenError: fmt.Errorf("random error"), want: false},
+		{name: "anyAmqpError", givenError: &amqp.Error{}, want: false},
+		{name: "AmqpInternalError", givenError: &amqp.Error{
+			Condition:   amqp.ErrorInternalError,
+			Description: "The service was unable to process the request",
+			Info:        nil,
+		}, want: true},
+		{name: "temporaryError", givenError: temporaryError{}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsConnectionDead(tt.givenError); got != tt.want {
+				t.Errorf("IsConnectionDead() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/run-integration.sh
+++ b/run-integration.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 go get github.com/jstemmer/go-junit-report
-go test -timeout 30m --tags=integration,debug -v ./integration | tee >(go-junit-report > integration.junit.xml)
+go test -timeout 30m --tags=integration,debug -v ./integration "$@" | tee >(go-junit-report > integration.junit.xml)


### PR DESCRIPTION
We've identified that amqp-internal error are not transient as the message lets you believe.
restarting the process was the only way to fix it.
this attempts to handle the error the same way as for a network errors.

this could be moved into the servicebus sdk to follow these other error handling scenarios:
https://github.com/Azure/azure-service-bus-go/blob/319bf88d3749af809309efdfb6498a790d5b0f44/sender.go#L251-L268

It should also be checked with the Servicebus team as the error message states incorrectly to "retry later". 