### PR TITLE
fix deadline context leak

### DIFF
--- a/handlers/lockrenewer_test.go
+++ b/handlers/lockrenewer_test.go
@@ -12,11 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type NoOpHandler struct {
+type FakeHandler struct {
+	Ctx        context.Context
+	Msg        *servicebus.Message
+	HandleFunc func(ctx context.Context, msg *servicebus.Message) error
 }
 
-func (h *NoOpHandler) Handle(_ context.Context, _ *servicebus.Message) error {
-	return nil
+func (h *FakeHandler) Handle(ctx context.Context, msg *servicebus.Message) error {
+	h.Ctx = ctx
+	h.Msg = msg
+	if h.HandleFunc == nil {
+		return nil
+	}
+	return h.HandleFunc(ctx, msg)
 }
 
 type testLockRenewer struct {
@@ -33,7 +41,7 @@ var _ handlers.LockRenewer = &testLockRenewer{}
 func Test_RenewPeriodically(t *testing.T) {
 	renewer := &testLockRenewer{}
 	interval := 50 * time.Millisecond
-	lr := handlers.NewPeekLockRenewer(&interval, renewer, &NoOpHandler{})
+	lr := handlers.NewPeekLockRenewer(&interval, renewer, &FakeHandler{})
 	msg := &servicebus.Message{}
 	ctx, _ := context.WithTimeout(context.TODO(), 120*time.Millisecond)
 	lr.Handle(ctx, msg)
@@ -47,7 +55,7 @@ func Test_RenewLockMetrics(t *testing.T) {
 	listener.Metrics.Init(reg)
 	renewer := &testLockRenewer{}
 	interval := 10 * time.Millisecond
-	lr := handlers.NewPeekLockRenewer(&interval, renewer, &NoOpHandler{})
+	lr := handlers.NewPeekLockRenewer(&interval, renewer, &FakeHandler{})
 	msg := &servicebus.Message{}
 	lr.Handle(context.TODO(), msg)
 	if !assert.Eventually(t, func() bool { return renewer.RenewCount == 2 }, 35*time.Millisecond, 5*time.Millisecond) {
@@ -68,7 +76,7 @@ func Test_RenewLockMetrics(t *testing.T) {
 func Test_RenewPeriodically_ContextCanceled(t *testing.T) {
 	renewer := &testLockRenewer{}
 	interval := 50 * time.Millisecond
-	lr := handlers.NewPeekLockRenewer(&interval, renewer, &NoOpHandler{})
+	lr := handlers.NewPeekLockRenewer(&interval, renewer, &FakeHandler{})
 	msg := &servicebus.Message{}
 	ctx, _ := context.WithTimeout(context.TODO(), 45*time.Millisecond)
 	lr.Handle(ctx, msg)

--- a/handlers/messagecontext.go
+++ b/handlers/messagecontext.go
@@ -34,12 +34,11 @@ func NewDeadlineContext(next servicebus.Handler) servicebus.Handler {
 }
 
 func setupDeadline(ctx context.Context, msg *servicebus.Message) (context.Context, func()) {
-	msgCtx, cancel := context.WithCancel(ctx)
 	if hasDeadline(msg) {
 		deadline := msg.SystemProperties.EnqueuedTime.Add(*msg.TTL)
-		msgCtx, _ = context.WithDeadline(ctx, deadline)
+		return context.WithDeadline(ctx, deadline)
 	}
-	return msgCtx, cancel
+	return context.WithCancel(ctx)
 }
 
 func hasDeadline(msg *servicebus.Message) bool {

--- a/handlers/messagecontext_test.go
+++ b/handlers/messagecontext_test.go
@@ -1,0 +1,42 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-shuttle/handlers"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CancelContextWhenDoneWithMessage(t *testing.T) {
+	next := &FakeHandler{}
+	handler := handlers.NewDeadlineContext(next)
+	ctx := context.Background()
+	ttlMessage := &servicebus.Message{}
+	err := handler.Handle(ctx, ttlMessage)
+	assert.Nil(t, err)
+	assert.Equal(t, context.Canceled, next.Ctx.Err())
+}
+
+func Test_CancelContextWhenDeadlineExceeded(t *testing.T) {
+	next := &FakeHandler{}
+	enqueuedTime := time.Now()
+	ttl := 1 * time.Microsecond
+	next.HandleFunc = func(ctx context.Context, msg *servicebus.Message) error {
+		time.Sleep(2 * ttl) // ensure we pass the deadline
+		return nil
+	}
+	handler := handlers.NewDeadlineContext(next)
+	ctx := context.Background()
+	ttlMessage := &servicebus.Message{
+		SystemProperties: &servicebus.SystemProperties{
+			EnqueuedTime: &enqueuedTime,
+		},
+		TTL: &ttl,
+	}
+	err := handler.Handle(ctx, ttlMessage)
+	assert.Nil(t, err)
+	assert.Equal(t, context.DeadlineExceeded, next.Ctx.Err())
+}


### PR DESCRIPTION
When an incoming has a TTL set, the message context handler was returning a deadline context, but with the cancel func from the original cancel context.
this means that the wrong cancel was being called and that the LockRenewer was running indefinitely in the background, creating sessions on the link that never got closed. it eventually reaches "max session" and stops working.

This returns the correct context, which will stop the renewer as soon as a message is done being handled.