### PR TITLE
Add deadletter monitoring

### DIFF
--- a/deadletter/deadletter.go
+++ b/deadletter/deadletter.go
@@ -1,0 +1,59 @@
+package deadletter
+
+import (
+	"context"
+	"time"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/Azure/go-shuttle/prometheus/listener"
+	"github.com/devigned/tab"
+)
+
+const timeout = time.Second * 2
+
+type Monitor struct {
+	topicName        string
+	subscriptionName string
+	counter          Counter
+	recorder         listener.DLQRecorder
+}
+
+func (m *Monitor) Run(ctx context.Context) {
+	for ctx.Err() == nil {
+		callCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		m.ReportDeadLetterCount(callCtx) // ignore error as we just log it in internal the span at this point
+		cancel()
+	}
+}
+
+func (m *Monitor) ReportDeadLetterCount(ctx context.Context) error {
+	callCtx, span := tab.StartSpan(ctx, "go-shuttle.deadLetterMonitor.Run")
+	defer span.End()
+	countDetails, err := m.counter.CountDetails(callCtx)
+	if err != nil {
+		span.Logger().Error(err)
+		return err
+	}
+	dlqCount := countDetails.DeadLetterMessageCount
+	if dlqCount != nil {
+		m.recorder.SetDeadLetterMessageCount(m.topicName, m.subscriptionName, float64(*dlqCount))
+	}
+	transferDlqCount := countDetails.TransferDeadLetterMessageCount
+	if transferDlqCount != nil {
+		m.recorder.SetTransferDeadLetterMessageCount(m.topicName, m.subscriptionName, float64(*transferDlqCount))
+	}
+	return nil
+}
+
+type Counter interface {
+	CountDetails(ctx context.Context) (*servicebus.CountDetails, error)
+}
+
+func StartMonitoring(ctx context.Context, c Counter, topicName, subscriptionName string) {
+	m := &Monitor{
+		counter:          c,
+		topicName:        topicName,
+		subscriptionName: subscriptionName,
+	}
+	m.Run(ctx)
+}

--- a/handlers/lockrenewer.go
+++ b/handlers/lockrenewer.go
@@ -62,12 +62,12 @@ func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *s
 			}
 			listener.Metrics.IncMessageLockRenewedSuccess(message)
 		case <-ctx.Done():
+			alive = false
 			span.Logger().Info("Stopping periodic renewal")
 			err := ctx.Err()
 			if errors.Is(err, context.DeadlineExceeded) {
 				listener.Metrics.IncMessageDeadlineReachedCount(message)
 			}
-			alive = false
 		}
 	}
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -20,19 +20,19 @@ const (
 
 // Listener is a struct to contain service bus entities relevant to subscribing to a publisher topic
 type Listener struct {
-	namespace           *servicebus.Namespace
-	topicEntity         *servicebus.TopicEntity
-	subscriptionEntity  *servicebus.SubscriptionEntity
-	listenerHandle      *servicebus.ListenerHandle
-	topicName           string
-	subscriptionName    string
-	maxDeliveryCount    int32
-	lockRenewalInterval *time.Duration
-	lockDuration        time.Duration
-	filterDefinitions   []*filterDefinition
-	prefetchCount       *uint32
-	maxConcurrency      *int
-	enableDLQMonitoring bool
+	namespace             *servicebus.Namespace
+	topicEntity           *servicebus.TopicEntity
+	subscriptionEntity    *servicebus.SubscriptionEntity
+	listenerHandle        *servicebus.ListenerHandle
+	topicName             string
+	subscriptionName      string
+	maxDeliveryCount      int32
+	lockRenewalInterval   *time.Duration
+	lockDuration          time.Duration
+	filterDefinitions     []*filterDefinition
+	prefetchCount         *uint32
+	maxConcurrency        *int
+	dlqMonitoringInterval *time.Duration
 }
 
 // Subscription returns the servicebus.SubscriptionEntity that the listener is setup with
@@ -139,8 +139,8 @@ func (l *Listener) Listen(ctx context.Context, handler message.Handler, topicNam
 		return fmt.Errorf("failed to create new subscription %s: %w", l.subscriptionEntity.Name, err)
 	}
 
-	if l.enableDLQMonitoring {
-		go deadletter.Monitor(ctx, l, l.topicName, l.subscriptionName)
+	if l.dlqMonitoringInterval != nil {
+		go deadletter.StartMonitoring(ctx, l, *l.dlqMonitoringInterval, l.topicName, l.subscriptionName)
 	}
 
 	var receiverOpts []servicebus.ReceiverOption

--- a/listener/options.go
+++ b/listener/options.go
@@ -186,9 +186,9 @@ func WithMaxConcurrency(concurrency int) Option {
 }
 
 // WithDeadLetterQueueMonitoring emits dead letter queue metric in the prometheus registry
-func WithDeadLetterQueueMonitoring(concurrency int) Option {
+func WithDeadLetterQueueMonitoring(interval time.Duration) Option {
 	return func(l *Listener) error {
-		l.enableDLQMonitoring = true
+		l.dlqMonitoringInterval = &interval
 		return nil
 	}
 }

--- a/listener/options.go
+++ b/listener/options.go
@@ -184,3 +184,11 @@ func WithMaxConcurrency(concurrency int) Option {
 		return nil
 	}
 }
+
+// WithDeadLetterQueueMonitoring emits dead letter queue metric in the prometheus registry
+func WithDeadLetterQueueMonitoring(concurrency int) Option {
+	return func(l *Listener) error {
+		l.enableDLQMonitoring = true
+		return nil
+	}
+}


### PR DESCRIPTION
This allows to start a dead letter queue monitoring routine in the background of the listener.
It periodically looks at the message count on the dead letter queues associated with the subscription/queue and reports it as a prometheus metric

TODO:
[ ] Add tests
[ ] Add doc