### PR TITLE
add delete subscription function

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -164,6 +164,32 @@ func (l *Listener) Listen(ctx context.Context, handler message.Handler, topicNam
 	return listenerHandle.Err()
 }
 
+// DeleteSubscriptions deletes the giving subscriptions
+func (l *Listener) DeleteSubscriptions(ctx context.Context, topicName, subscriptionName []string) error {
+	if l.topicEntity == nil {
+		return fmt.Errorf("entity of topic is nil")
+	}
+
+	subManager, err := l.namespace.NewSubscriptionManager(l.topicEntity.Name)
+	if err != nil {
+		return fmt.Errorf("Failed to create subscription manager, err: %s", err)
+	}
+
+	errorMsg := ""
+	for _, subName := range subscriptionName {
+		err = subManager.Delete(ctx, subName)
+		if err != nil {
+			errorMsg += err.Error()
+		}
+	}
+
+	if errorMsg != "" {
+		return fmt.Errorf(errorMsg)
+	}
+
+	return nil
+}
+
 // Close closes the listener if an active listener exists
 func (l *Listener) Close(ctx context.Context) error {
 	if l.listenerHandle == nil {


### PR DESCRIPTION
the current change added a function to clean up subscription that we don't need anymore. we can all it with old subscription names. There might be other options to do that, but I feel like they might be risky, 
1. in listener, list all subscriptions, delete other subscriptions that not currently in use. this will only allow one subscription, so don't think it's the right thing to do. 
2. use servicebus option SubscriptionWithAutoDeleteOnIdle (assuming we can set it on existing subscription), we can set a time window, the subscription will be deleted after the time window. The concern is if our worker is offline for a while, the subscription might be deleted, and when the worker comes back online, a new subscription will be created, but we may lose the messages in between.