### PR TITLE
Fix amqp-internal error recovery detection

### DIFF
--- a/common/errorhandling/recovery.go
+++ b/common/errorhandling/recovery.go
@@ -24,7 +24,7 @@ func isAmqpInternalError(err error) bool {
 	var amqpErr *amqp.Error
 	return errors.As(err, &amqpErr) &&
 		amqpErr.Condition == amqp.ErrorInternalError &&
-		strings.HasPrefix("the service was unable to process the request", strings.ToLower(amqpErr.Description))
+		strings.HasPrefix(strings.ToLower(amqpErr.Description), "the service was unable to process the request")
 }
 
 func isPermanentNetError(err error) bool {

--- a/common/errorhandling/recovery_test.go
+++ b/common/errorhandling/recovery_test.go
@@ -41,7 +41,7 @@ func TestIsConnectionDead(t *testing.T) {
 		{name: "sb.ErrConnClosed", givenError: servicebus.ErrConnectionClosed("Blah"), want: true},
 		{name: "AmqpInternalError", givenError: &amqp.Error{
 			Condition:   amqp.ErrorInternalError,
-			Description: "The service was unable to process the request",
+			Description: "The service was unable to process the request, please retry",
 			Info:        nil,
 		}, want: true},
 		{name: "temporaryError", givenError: temporaryError{}, want: false},


### PR DESCRIPTION
The PR is self explaining, the prefix verification arguments were in the wrong order. 
This caused the service to sometimes avoid reconnecting. (Depending if it caught the initial read timeout).