### PR TITLE
implement log and metrics integration support

### DIFF
--- a/v2/e2e/suite_test.go
+++ b/v2/e2e/suite_test.go
@@ -62,6 +62,10 @@ func randomString(prefix string, length int) string {
 }
 
 func TestSuite(t *testing.T) {
+    t.Helper()
+    if os.Getenv("INTEGRATION") == "" {
+        t.Skip("skipping integration tests, set environment variable INTEGRATION")
+    }
 	suite.Run(t, &SBSuite{Prefix: "v5"})
 }
 

--- a/v2/metrics/registry.go
+++ b/v2/metrics/registry.go
@@ -58,11 +58,12 @@ func getMessageTypeLabel(msg *azservicebus.ReceivedMessage) prom.Labels {
 }
 
 func (m *Registry) Init(reg prom.Registerer) {
-	reg.MustRegister(m.MessageHandledCount,
+	reg.MustRegister(
+		m.MessageReceivedCount,
+		m.MessageHandledCount,
 		m.MessageLockRenewedCount,
 		m.MessageDeadlineReachedCount,
-		m.ConcurrentMessageCount,
-		m.ConnectionRecovery)
+		m.ConcurrentMessageCount)
 }
 
 type Registry struct {
@@ -71,7 +72,6 @@ type Registry struct {
 	MessageLockRenewedCount     *prom.CounterVec
 	MessageDeadlineReachedCount *prom.CounterVec
 	ConcurrentMessageCount      *prom.GaugeVec
-	ConnectionRecovery          *prom.CounterVec
 }
 
 type Recorder interface {

--- a/v2/metrics/registry.go
+++ b/v2/metrics/registry.go
@@ -1,0 +1,166 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	prom "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+const (
+	subsystem          = "goshuttle_handler"
+	messageTypeLabel   = "messageType"
+	deliveryCountLabel = "deliveryCount"
+	successLabel       = "success"
+)
+
+var (
+	metricsRegistry          = newRegistry()
+	Processor       Recorder = metricsRegistry
+)
+
+func newRegistry() *Registry {
+	return &Registry{
+		MessageReceivedCount: prom.NewCounterVec(prom.CounterOpts{
+			Name:      "message_received_total",
+			Help:      "total number of messages received by the processor",
+			Subsystem: subsystem,
+		}, []string{}),
+		MessageHandledCount: prom.NewCounterVec(prom.CounterOpts{
+			Name:      "message_handled_total",
+			Help:      "total number of messages handled by this handler",
+			Subsystem: subsystem,
+		}, []string{messageTypeLabel, deliveryCountLabel}),
+		MessageLockRenewedCount: prom.NewCounterVec(prom.CounterOpts{
+			Name:      "message_lock_renewed_total",
+			Help:      "total number of message lock renewal",
+			Subsystem: subsystem,
+		}, []string{messageTypeLabel, successLabel}),
+		MessageDeadlineReachedCount: prom.NewCounterVec(prom.CounterOpts{
+			Name:      "message_deadline_reached_total",
+			Help:      "total number of message lock renewal",
+			Subsystem: subsystem,
+		}, []string{messageTypeLabel}),
+		ConcurrentMessageCount: prom.NewGaugeVec(prom.GaugeOpts{
+			Name:      "concurrent_message_count",
+			Help:      "number of messages being handled concurrently",
+			Subsystem: subsystem,
+		}, []string{messageTypeLabel}),
+	}
+}
+
+func getMessageTypeLabel(msg *azservicebus.ReceivedMessage) prom.Labels {
+	typeName := msg.ApplicationProperties["type"]
+	return map[string]string{
+		messageTypeLabel: fmt.Sprintf("%s", typeName),
+	}
+}
+
+func (m *Registry) Init(reg prom.Registerer) {
+	reg.MustRegister(m.MessageHandledCount,
+		m.MessageLockRenewedCount,
+		m.MessageDeadlineReachedCount,
+		m.ConcurrentMessageCount,
+		m.ConnectionRecovery)
+}
+
+type Registry struct {
+	MessageReceivedCount        *prom.CounterVec
+	MessageHandledCount         *prom.CounterVec
+	MessageLockRenewedCount     *prom.CounterVec
+	MessageDeadlineReachedCount *prom.CounterVec
+	ConcurrentMessageCount      *prom.GaugeVec
+	ConnectionRecovery          *prom.CounterVec
+}
+
+type Recorder interface {
+	Init(registerer prom.Registerer)
+	IncMessageDeadlineReachedCount(msg *azservicebus.ReceivedMessage)
+	IncMessageLockRenewedFailure(msg *azservicebus.ReceivedMessage)
+	IncMessageLockRenewedSuccess(msg *azservicebus.ReceivedMessage)
+	DecConcurrentMessageCount(msg *azservicebus.ReceivedMessage)
+	IncMessageHandled(msg *azservicebus.ReceivedMessage)
+	IncMessageReceived(float64)
+	IncConcurrentMessageCount(msg *azservicebus.ReceivedMessage)
+}
+
+func (m *Registry) IncMessageLockRenewedSuccess(msg *azservicebus.ReceivedMessage) {
+	labels := getMessageTypeLabel(msg)
+	labels[successLabel] = "true"
+	m.MessageLockRenewedCount.With(labels).Inc()
+}
+
+func (m *Registry) IncMessageLockRenewedFailure(msg *azservicebus.ReceivedMessage) {
+	labels := getMessageTypeLabel(msg)
+	labels[successLabel] = "false"
+	m.MessageLockRenewedCount.With(labels).Inc()
+}
+
+func (m *Registry) IncMessageHandled(msg *azservicebus.ReceivedMessage) {
+	labels := getMessageTypeLabel(msg)
+	labels[deliveryCountLabel] = fmt.Sprintf("%d", msg.DeliveryCount)
+	m.MessageHandledCount.With(labels).Inc()
+}
+
+func (m *Registry) IncConcurrentMessageCount(msg *azservicebus.ReceivedMessage) {
+	m.ConcurrentMessageCount.With(getMessageTypeLabel(msg)).Inc()
+}
+
+func (m *Registry) DecConcurrentMessageCount(msg *azservicebus.ReceivedMessage) {
+	m.ConcurrentMessageCount.With(getMessageTypeLabel(msg)).Dec()
+}
+
+func (m *Registry) IncMessageDeadlineReachedCount(msg *azservicebus.ReceivedMessage) {
+	labels := getMessageTypeLabel(msg)
+	m.MessageDeadlineReachedCount.With(labels).Inc()
+}
+
+func (m *Registry) IncMessageReceived(count float64) {
+	m.MessageReceivedCount.With(map[string]string{}).Add(count)
+}
+
+type Informer struct {
+	registry *Registry
+}
+
+func NewInformer() *Informer {
+	return &Informer{registry: metricsRegistry}
+}
+
+func (i *Informer) GetMessageLockRenewedFailureCount() (float64, error) {
+	var total float64
+	collect(i.registry.MessageLockRenewedCount, func(m dto.Metric) {
+		if !hasLabel(m, successLabel, "false") {
+			return
+		}
+		total += m.GetCounter().GetValue()
+	})
+	return total, nil
+}
+
+func hasLabel(m dto.Metric, key string, value string) bool {
+	for _, pair := range m.Label {
+		if pair == nil {
+			continue
+		}
+		if pair.GetName() == key && pair.GetValue() == value {
+			return true
+		}
+	}
+	return false
+}
+
+// collect calls the function for each metric associated with the Collector
+func collect(col prom.Collector, do func(dto.Metric)) {
+	c := make(chan prom.Metric)
+	go func(c chan prom.Metric) {
+		col.Collect(c)
+		close(c)
+	}(c)
+	for x := range c { // eg range across distinct label vector values
+		m := dto.Metric{}
+		_ = x.Write(&m)
+		do(m)
+	}
+}

--- a/v2/metrics/registry_test.go
+++ b/v2/metrics/registry_test.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type fakeRegistry struct {
+	collectors []prometheus.Collector
+}
+
+func (f *fakeRegistry) Register(c prometheus.Collector) error {
+	panic("implement me")
+}
+
+func (f *fakeRegistry) MustRegister(c ...prometheus.Collector) {
+	f.collectors = append(f.collectors, c...)
+}
+
+func (f *fakeRegistry) Unregister(c prometheus.Collector) bool {
+	panic("implement me")
+}
+
+func TestRegistry_Init(t *testing.T) {
+	g := NewWithT(t)
+	r := newRegistry()
+	fRegistry := &fakeRegistry{}
+	g.Expect(func() { r.Init(prometheus.NewRegistry()) }).ToNot(Panic())
+	g.Expect(func() { r.Init(fRegistry) }).ToNot(Panic())
+	g.Expect(fRegistry.collectors).To(HaveLen(5))
+}
+
+func TestInformer_GetMetric(t *testing.T) {
+	g := NewWithT(t)
+	r := newRegistry()
+	registerer := prometheus.NewRegistry()
+	informer := &Informer{registry: r}
+
+	// before init
+	count, err := informer.GetMessageLockRenewedFailureCount()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(float64(0)))
+
+	// after init, count 0
+	g.Expect(func() { r.Init(registerer) }).ToNot(Panic())
+	count, err = informer.GetMessageLockRenewedFailureCount()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(float64(0)))
+
+	// count incremented
+	msg := &azservicebus.ReceivedMessage{}
+	msg.ApplicationProperties = map[string]interface{}{
+		"type": "someType",
+	}
+	r.IncMessageLockRenewedFailure(msg)
+	count, err = informer.GetMessageLockRenewedFailureCount()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(float64(1)))
+
+	// count failure only
+	r.IncMessageLockRenewedSuccess(msg)
+	count, err = informer.GetMessageLockRenewedFailureCount()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(float64(1)))
+}

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/go-shuttle/v2/metrics"
+	"github.com/devigned/tab"
 )
 
 type Receiver interface {
@@ -75,6 +77,7 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 func (p *Processor) Start(ctx context.Context) error {
 	messages, err := p.receiver.ReceiveMessages(ctx, p.options.MaxConcurrency, nil)
 	log(ctx, "received ", len(messages), " messages - initial")
+	metrics.Processor.IncMessageReceived(float64(len(messages)))
 	if err != nil {
 		return err
 	}
@@ -90,6 +93,7 @@ func (p *Processor) Start(ctx context.Context) error {
 			}
 			messages, err := p.receiver.ReceiveMessages(ctx, maxMessages, nil)
 			log(ctx, "received ", len(messages), " messages from loop")
+			metrics.Processor.IncMessageReceived(float64(len(messages)))
 			if err != nil {
 				return err
 			}
@@ -112,7 +116,10 @@ func (p *Processor) process(ctx context.Context, message *azservicebus.ReceivedM
 		defer cancel()
 		defer func() {
 			<-p.concurrencyTokens
+			metrics.Processor.IncMessageHandled(message)
+			metrics.Processor.DecConcurrentMessageCount(message)
 		}()
+		metrics.Processor.IncConcurrentMessageCount(message)
 		p.handle(msgContext, p.receiver, message)
 	}()
 }
@@ -150,32 +157,30 @@ type peekLockRenewer struct {
 }
 
 func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *azservicebus.ReceivedMessage) {
-	// _, span := tracing.StartSpanFromMessageAndContext(ctx, "go-shuttle.peeklock.startPeriodicRenewal", message)
-	// defer span.End()
 	count := 0
 	for alive := true; alive; {
 		select {
 		case <-time.After(*plr.renewalInterval):
 			log(ctx, "renewing lock")
 			count++
-			// tab.For(ctx).Debug("Renewing message lock", tab.Int64Attribute("count", int64(count)))
+			tab.For(ctx).Debug("Renewing message lock", tab.Int64Attribute("count", int64(count)))
 			err := plr.lockRenewer.RenewMessageLock(ctx, message, nil)
 			if err != nil {
 				log(ctx, "failed to renew lock: ", err)
-				// listener.Metrics.IncMessageLockRenewedFailure(message)
+				metrics.Processor.IncMessageLockRenewedFailure(message)
 				// I don't think this is a problem. the context is canceled when the message processing is over.
 				// this can happen if we already entered the interval case when the message is completing.
-				// tab.For(ctx).Info("failed to renew the peek lock", tab.StringAttribute("reason", err.Error()))
+				tab.For(ctx).Error(fmt.Errorf("failed to renew lock: %w", err))
 				return
 			}
-			// tab.For(ctx).Debug("renewed lock success")
-			// listener.Metrics.IncMessageLockRenewedSuccess(message)
+			tab.For(ctx).Debug("renewed lock success")
+			metrics.Processor.IncMessageLockRenewedSuccess(message)
 		case <-ctx.Done():
-			log(ctx, ctx, "context done, stop lock renewal")
-			// tab.For(ctx).Info("Stopping periodic renewal")
+			log(ctx, ctx, "context done: stopping periodic renewal")
+			tab.For(ctx).Info("stopping periodic renewal")
 			err := ctx.Err()
 			if errors.Is(err, context.DeadlineExceeded) {
-				// listener.Metrics.IncMessageDeadlineReachedCount(message)
+				metrics.Processor.IncMessageDeadlineReachedCount(message)
 			}
 			alive = false
 		}
@@ -204,11 +209,6 @@ func (l *printLogger) Error(s string) {
 	fmt.Println(append(append([]any{}, "ERROR - ", time.Now().UTC(), " - "), s)...)
 }
 
-func ConfigureLogger(getLoggerFunc func(ctx context.Context) Logger) {
-	getLogger = getLoggerFunc
-}
-
-// dumb log until we integrate logging
 func log(ctx context.Context, a ...any) {
 	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
 		getLogger(ctx).Info(fmt.Sprint(append(append([]any{}, time.Now().UTC(), " - "), a...)...))


### PR DESCRIPTION
Log integration allows to configure goshuttle package to use a `GetLogger(context.Context)` func to retrieve a logger.
this allows a per message logger to be retrieved, and used by our library if configured.

Metrics integration is a direct port from v1 to v2.
