### PR TITLE
chore: [tracing] move tracing things around

### DIFF
--- a/v2/otel/otel_test.go
+++ b/v2/otel/otel_test.go
@@ -1,8 +1,7 @@
-package tracing
+package otel
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func Test_TracingMiddleware(t *testing.T) {
@@ -58,46 +56,15 @@ func Test_TracingMiddleware(t *testing.T) {
 			g := NewGomegaWithT(t)
 			if tc.carryRemoteSpan {
 				propogator := propagation.TraceContext{}
-				propogator.Inject(remoteCtx, carrierAdapterForReceivedMsg(tc.message))
+				propogator.Inject(remoteCtx, ReceivedMessageCarrierAdapter(tc.message))
 				_, remoteSpan := getRemoteParentSpan(context.TODO(), tc.message)
 				g.Expect(remoteSpan.SpanContext().IsValid()).To(BeTrue())
 				g.Expect(remoteSpan.SpanContext().IsRemote()).To(BeTrue())
 			}
 
-			_, span := applyTracingMiddleWare(context.TODO(), tc.message)
+			_, span := Extract(context.TODO(), tc.message)
 			g.Expect(span.SpanContext().IsValid()).To(BeTrue())
 		})
-	}
-}
-
-func TestHandlers_SetMessageTrace(t *testing.T) {
-	blankMsg := &azservicebus.Message{}
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSampler(tracesdk.AlwaysSample()))
-
-	// fake a remote span
-	remoteCtx, remoteSpan := tp.Tracer("test-tracer").Start(context.Background(), "remote-span")
-	remoteSpan.End()
-
-	// Inject the trace context into the message
-	handler := PropagateFromContext(remoteCtx)
-	if err := handler(blankMsg); err != nil {
-		t.Errorf("Unexpected error in set trace carrier test: %s", err)
-	}
-
-	if blankMsg.ApplicationProperties == nil {
-		t.Errorf("for trace carrier expected application properties to be set")
-	}
-
-	propogator := propagation.TraceContext{}
-	ctx := propogator.Extract(context.TODO(), carrierAdapterForMsg(blankMsg))
-	extractedSpan := trace.SpanFromContext(ctx)
-
-	if !extractedSpan.SpanContext().IsValid() || !extractedSpan.SpanContext().IsRemote() {
-		t.Errorf("expected extracted span to be valid and remote")
-	}
-
-	if reflect.DeepEqual(extractedSpan, remoteSpan) {
-		t.Errorf("expected extracted span to be the same with remote span")
 	}
 }
 

--- a/v2/tracing.go
+++ b/v2/tracing.go
@@ -1,0 +1,26 @@
+package shuttle
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/go-shuttle/v2/otel"
+)
+
+// NewTracingHandler is a shuttle middleware that extracts the context from the message Application property if available,
+// or from the existing context if not, and starts a span.
+func NewTracingHandler(next Handler) HandlerFunc {
+	return func(ctx context.Context, settler MessageSettler, message *azservicebus.ReceivedMessage) {
+		ctx, span := otel.Extract(ctx, message)
+		defer span.End()
+		next.Handle(ctx, settler, message)
+	}
+}
+
+// WithTracePropagation is a sender option to inject the trace context into the message
+func WithTracePropagation(ctx context.Context) func(msg *azservicebus.Message) error {
+	return func(message *azservicebus.Message) error {
+		otel.Inject(ctx, message)
+		return nil
+	}
+}

--- a/v2/tracing_test.go
+++ b/v2/tracing_test.go
@@ -1,0 +1,110 @@
+package shuttle_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/Azure/go-shuttle/v2"
+	"github.com/Azure/go-shuttle/v2/otel"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/otel/propagation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestHandlers_SetMessageTrace(t *testing.T) {
+	blankMsg := &azservicebus.Message{}
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSampler(tracesdk.AlwaysSample()))
+
+	// fake a remote span
+	remoteCtx, remoteSpan := tp.Tracer("test-tracer").Start(context.Background(), "remote-span")
+	remoteSpan.End()
+
+	// Inject the trace context into the message
+	handler := shuttle.WithTracePropagation(remoteCtx)
+	if err := handler(blankMsg); err != nil {
+		t.Errorf("Unexpected error in set trace carrier test: %s", err)
+	}
+
+	if blankMsg.ApplicationProperties == nil {
+		t.Errorf("for trace carrier expected application properties to be set")
+	}
+
+	propogator := propagation.TraceContext{}
+	ctx := propogator.Extract(context.TODO(), otel.MessageCarrierAdapter(blankMsg))
+	extractedSpan := trace.SpanFromContext(ctx)
+
+	if !extractedSpan.SpanContext().IsValid() || !extractedSpan.SpanContext().IsRemote() {
+		t.Errorf("expected extracted span to be valid and remote")
+	}
+
+	if reflect.DeepEqual(extractedSpan, remoteSpan) {
+		t.Errorf("expected extracted span to be the same with remote span")
+	}
+}
+
+func Test_NewTracingHandler(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		hasTraceContextOnContext bool
+		hasTraceContextOnMessage bool
+	}{
+		{
+			name:                     "no traceCtx - local traceContext added",
+			hasTraceContextOnContext: false,
+			hasTraceContextOnMessage: false,
+		},
+		{
+			name:                     "has traceCtx on context - use the one on context",
+			hasTraceContextOnContext: true,
+			hasTraceContextOnMessage: false,
+		},
+		{
+			name:                     "has traceCtx on message - extract from message ",
+			hasTraceContextOnContext: true,
+			hasTraceContextOnMessage: true,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(tt)
+			settler := &fakeSettler{}
+			contextTraceID := trace.TraceID{1, 2, 3}
+			messageTraceID := trace.TraceID{2, 3, 4}
+			var spanCtx trace.SpanContext
+			h := shuttle.NewTracingHandler(
+				shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler, message *azservicebus.ReceivedMessage) {
+					spanCtx = trace.SpanContextFromContext(ctx)
+				}))
+
+			ctx := context.TODO()
+			if tc.hasTraceContextOnContext {
+				ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: contextTraceID,
+					SpanID:  trace.SpanID{1, 2, 3},
+				}))
+			}
+
+			msg := &azservicebus.ReceivedMessage{}
+			if tc.hasTraceContextOnMessage {
+				msgContext := trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: messageTraceID,
+					SpanID:  trace.SpanID{1, 2, 3},
+				}))
+				propogator := propagation.TraceContext{}
+				propogator.Inject(msgContext, otel.ReceivedMessageCarrierAdapter(msg))
+			}
+
+			h.Handle(ctx, settler, msg)
+			if tc.hasTraceContextOnMessage {
+				g.Expect(spanCtx.TraceID()).To(Equal(messageTraceID))
+			} else if tc.hasTraceContextOnContext {
+				g.Expect(spanCtx.TraceID()).To(Equal(contextTraceID))
+			}
+			g.Expect(spanCtx.IsRemote()).To(Equal(tc.hasTraceContextOnMessage))
+		})
+	}
+}


### PR DESCRIPTION
move the shuttle dependent bits to the v2 root to avoid circular dependency
rename tracing package to otel