### PR TITLE
adding peek message method to receiver interface

### DIFF
--- a/v2/processor.go
+++ b/v2/processor.go
@@ -16,6 +16,7 @@ import (
 
 type Receiver interface {
 	ReceiveMessages(ctx context.Context, maxMessages int, options *azservicebus.ReceiveMessagesOptions) ([]*azservicebus.ReceivedMessage, error)
+	PeekMessages(ctx context.Context, maxMessageCount int, options *azservicebus.PeekMessagesOptions) ([]*azservicebus.ReceivedMessage, error)
 	MessageSettler
 }
 


### PR DESCRIPTION
Making this PR to add the PeekMessage method to the Receiver interface. 

My use case for this is that we need the go-shuttle Receivers we create to be interchangeable with the structs that represent our old operation queue. In order to do that, I'm wrapping our go-shuttle receivers in a struct that has the same methods as the old operation queue, but one of those a peek message method.

Beyond that, we've had a few situations where we needed a peek message method to verify connection to our servicebus queue when we create senders and receivers.