### PR TITLE
:recycle: use an interface for the ManagedSettlingHandler

### DIFF
--- a/v2/managedsettling_example_test.go
+++ b/v2/managedsettling_example_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+
 	"github.com/Azure/go-shuttle/v2"
 )
 
@@ -46,14 +47,14 @@ func ExampleNewManagedSettlingHandler() {
 	cancel()
 }
 
-func myManagedSettlementHandler() shuttle.ManagedSettlingFunc {
+func myManagedSettlementHandler() shuttle.ManagedSettlingHandler {
 	count := 0
-	return func(ctx context.Context, message *azservicebus.ReceivedMessage) error {
+	return shuttle.ManagedSettlingFunc(func(ctx context.Context, message *azservicebus.ReceivedMessage) error {
 		count++
 		if count == 0 {
 			// this will abandon the message
 			return fmt.Errorf("this will abandon the message, and eventually move it to DLQ")
 		}
 		return nil // this will complete the message
-	}
+	})
 }

--- a/v2/managedsettling_test.go
+++ b/v2/managedsettling_test.go
@@ -162,9 +162,9 @@ func Test_NilErr_WrappedInDeadLetter(t *testing.T) {
 func TestDefaultOptions_CallDefaultHooks(t *testing.T) {
 	h := NewManagedSettlingHandler(&ManagedSettlingOptions{
 		RetryDelayStrategy: &ConstantDelayStrategy{Delay: 0},
-	}, func(_ context.Context, _ *azservicebus.ReceivedMessage) error {
+	}, ManagedSettlingFunc(func(_ context.Context, _ *azservicebus.ReceivedMessage) error {
 		return nil
-	})
+	}))
 
 	settler := &fakeSettler{}
 	h.Handle(context.TODO(), settler, &azservicebus.ReceivedMessage{})
@@ -190,9 +190,9 @@ func TestOnErrorOverride(t *testing.T) {
 	opts.OnError = func(ctx context.Context, opts *ManagedSettlingOptions, settler MessageSettler, message *azservicebus.ReceivedMessage, handleErr error) {
 		onErrorCalled = true
 	}
-	h := NewManagedSettlingHandler(opts, func(_ context.Context, _ *azservicebus.ReceivedMessage) error {
+	h := NewManagedSettlingHandler(opts, ManagedSettlingFunc(func(_ context.Context, _ *azservicebus.ReceivedMessage) error {
 		return fmt.Errorf("failed")
-	})
+	}))
 	h.Handle(context.Background(), settler, &azservicebus.ReceivedMessage{})
 	g.Expect(onErrorCalled).To(BeTrue())
 }

--- a/v2/managedsettling_test.go
+++ b/v2/managedsettling_test.go
@@ -143,9 +143,9 @@ func TestManagedSettler_Handle(t *testing.T) {
 				},
 			}
 			h := NewManagedSettlingHandler(options,
-				func(ctx context.Context, message *azservicebus.ReceivedMessage) error {
+				ManagedSettlingFunc(func(ctx context.Context, message *azservicebus.ReceivedMessage) error {
 					return tc.handlerResponse
-				})
+				}))
 			h.Handle(context.TODO(), &tc.settler, tc.msg)
 			tc.expectation(tt, tc.hooks, &tc.settler)
 		})


### PR DESCRIPTION
use an interface in the ManagedSettling to simplify consumer code.