### PR TITLE
Ster/logging adapter

### DIFF
--- a/v2/logging.go
+++ b/v2/logging.go
@@ -13,8 +13,8 @@ type Logger interface {
 	Error(s string)
 }
 
-// SetGetLoggerFunc sets the function to be used to acquire a logger when go-shuttle logs.
-func SetGetLoggerFunc(fn func(ctx context.Context) Logger) {
+// SetLoggerFunc sets the function to be used to acquire a logger when go-shuttle logs.
+func SetLoggerFunc(fn func(ctx context.Context) Logger) {
 	getLogger = fn
 }
 

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -1,0 +1,36 @@
+package shuttle
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+type Logger interface {
+	Info(s string)
+	Warn(s string)
+	Error(s string)
+}
+
+var getLogger = func(_ context.Context) Logger { return &printLogger{} }
+
+type printLogger struct{}
+
+func (l *printLogger) Info(s string) {
+	fmt.Println(append(append([]any{}, "INFO - ", time.Now().UTC(), " - "), s)...)
+}
+
+func (l *printLogger) Warn(s string) {
+	fmt.Println(append(append([]any{}, "WARN - ", time.Now().UTC(), " - "), s)...)
+}
+
+func (l *printLogger) Error(s string) {
+	fmt.Println(append(append([]any{}, "ERROR - ", time.Now().UTC(), " - "), s)...)
+}
+
+func log(ctx context.Context, a ...any) {
+	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
+		getLogger(ctx).Info(fmt.Sprint(append(append([]any{}, time.Now().UTC(), " - "), a...)...))
+	}
+}

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -13,6 +13,11 @@ type Logger interface {
 	Error(s string)
 }
 
+// SetGetLoggerFunc sets the function to be used to acquire a logger when go-shuttle logs.
+func SetGetLoggerFunc(fn func(ctx context.Context) Logger) {
+	getLogger = fn
+}
+
 var getLogger = func(_ context.Context) Logger { return &printLogger{} }
 
 type printLogger struct{}

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -21,12 +21,12 @@ func (t testLogger) Error(s string) {
 	//TODO implement me
 }
 
-func getLogger(ctx context.Context) shuttle.Logger {
+func getLogger(_ context.Context) shuttle.Logger {
 	return &testLogger{}
 }
 
-func TestSetGetLoggerFunc(t *testing.T) {
-	shuttle.SetGetLoggerFunc(func(ctx context.Context) shuttle.Logger {
+func TestSetLoggerFunc(t *testing.T) {
+	shuttle.SetLoggerFunc(func(ctx context.Context) shuttle.Logger {
 		return getLogger(ctx)
 	})
 }

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -1,0 +1,32 @@
+package shuttle_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/go-shuttle/v2"
+)
+
+type testLogger struct{}
+
+func (t testLogger) Info(s string) {
+	//TODO implement me
+}
+
+func (t testLogger) Warn(s string) {
+	//TODO implement me
+}
+
+func (t testLogger) Error(s string) {
+	//TODO implement me
+}
+
+func getLogger(ctx context.Context) shuttle.Logger {
+	return &testLogger{}
+}
+
+func TestSetGetLoggerFunc(t *testing.T) {
+	shuttle.SetGetLoggerFunc(func(ctx context.Context) shuttle.Logger {
+		return getLogger(ctx)
+	})
+}

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
-	"github.com/Azure/go-shuttle/v2/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/Azure/go-shuttle/v2/metrics"
 )
 
 type Receiver interface {
@@ -217,33 +217,5 @@ func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *a
 			}
 			alive = false
 		}
-	}
-}
-
-type Logger interface {
-	Info(s string)
-	Warn(s string)
-	Error(s string)
-}
-
-var getLogger = func(_ context.Context) Logger { return &printLogger{} }
-
-type printLogger struct{}
-
-func (l *printLogger) Info(s string) {
-	fmt.Println(append(append([]any{}, "INFO - ", time.Now().UTC(), " - "), s)...)
-}
-
-func (l *printLogger) Warn(s string) {
-	fmt.Println(append(append([]any{}, "WARN - ", time.Now().UTC(), " - "), s)...)
-}
-
-func (l *printLogger) Error(s string) {
-	fmt.Println(append(append([]any{}, "ERROR - ", time.Now().UTC(), " - "), s)...)
-}
-
-func log(ctx context.Context, a ...any) {
-	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
-		getLogger(ctx).Info(fmt.Sprint(append(append([]any{}, time.Now().UTC(), " - "), a...)...))
 	}
 }


### PR DESCRIPTION
Adds shuttle.SetLoggerFunc to allow application to inject its own logger from context.
go-shuttle leaves it to the application to adapt their logger to the go-shuttle exposed Logger interface.