### PR TITLE
[fix] Stop lock-renewer when we know we can

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/v2-build-and-ut.yaml
+++ b/.github/workflows/v2-build-and-ut.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Build
         run: |

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,4 +1,4 @@
-go 1.18
+go 1.19
 
 module github.com/Azure/go-shuttle/v2
 

--- a/v2/lockrenewer.go
+++ b/v2/lockrenewer.go
@@ -68,8 +68,7 @@ func (plr *peekLockRenewer) isPermanent(err error) bool {
 func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *azservicebus.ReceivedMessage) {
 	count := 0
 	span := trace.SpanFromContext(ctx)
-	plr.alive.Store(true)
-	for plr.alive.Load() {
+	for plr.alive.Store(true); plr.alive.Load(); {
 		select {
 		case <-time.After(*plr.renewalInterval):
 			if !plr.alive.Load() {

--- a/v2/lockrenewer_test.go
+++ b/v2/lockrenewer_test.go
@@ -3,6 +3,7 @@ package shuttle_test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,13 +14,13 @@ import (
 )
 
 type fakeSBLockRenewer struct {
-	RenewCount int
+	RenewCount atomic.Int32
 	Err        error
 }
 
 func (r *fakeSBLockRenewer) RenewMessageLock(ctx context.Context, message *azservicebus.ReceivedMessage,
 	options *azservicebus.RenewMessageLockOptions) error {
-	r.RenewCount++
+	r.RenewCount.Add(1)
 	return r.Err
 }
 
@@ -36,48 +37,73 @@ func Test_RenewPeriodically(t *testing.T) {
 	lr.Handle(ctx, &fakeSettler{}, msg)
 	g := NewWithT(t)
 	g.Eventually(
-		func(g Gomega) { g.Expect(renewer.RenewCount).To(Equal(2)) },
+		func(g Gomega) { g.Expect(renewer.RenewCount.Load()).To(Equal(int32(2))) },
 		130*time.Millisecond,
 		20*time.Millisecond).Should(Succeed())
 }
 
 func Test_RenewPeriodically_Error(t *testing.T) {
-	renewer := &fakeSBLockRenewer{
-		Err: fmt.Errorf("fail to renew"),
+	type testCase struct {
+		name    string
+		renewer *fakeSBLockRenewer
+		verify  func(g Gomega, tc *testCase)
 	}
-	interval := 50 * time.Millisecond
-	lr := shuttle.NewRenewLockHandler(renewer, &interval, shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
-		message *azservicebus.ReceivedMessage) {
-		time.Sleep(150 * time.Millisecond)
-	}))
-	msg := &azservicebus.ReceivedMessage{}
-	ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Millisecond)
-	defer cancel()
-	lr.Handle(ctx, &fakeSettler{}, msg)
-
-	g := NewWithT(t)
-	// continue periodic renewal on Renew error
-	g.Eventually(
-		func(g Gomega) { g.Expect(renewer.RenewCount).To(Equal(2)) },
-		130*time.Millisecond,
-		20*time.Millisecond).Should(Succeed())
-}
-
-func Test_RenewPeriodically_ContextCanceled(t *testing.T) {
-	renewer := &fakeSBLockRenewer{
-		Err: fmt.Errorf("fail to renew"),
+	testCases := []testCase{
+		{
+			name:    "continue periodic renewal on unknown error",
+			renewer: &fakeSBLockRenewer{Err: fmt.Errorf("unknown error")},
+			verify: func(g Gomega, tc *testCase) {
+				g.Eventually(
+					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					130*time.Millisecond,
+					20*time.Millisecond).Should(Succeed())
+			},
+		},
+		{
+			name:    "stop periodic renewal on context canceled",
+			renewer: &fakeSBLockRenewer{Err: context.Canceled},
+			verify: func(g Gomega, tc *testCase) {
+				g.Consistently(
+					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					130*time.Millisecond,
+					20*time.Millisecond)
+			},
+		},
+		{
+			name:    "stop periodic renewal on permanent error (lockLost)",
+			renewer: &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
+			verify: func(g Gomega, tc *testCase) {
+				g.Consistently(
+					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					130*time.Millisecond,
+					20*time.Millisecond)
+			},
+		},
+		{
+			name:    "continue periodic renewal on transient error (timeout)",
+			renewer: &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeTimeout}},
+			verify: func(g Gomega, tc *testCase) {
+				g.Eventually(
+					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					130*time.Millisecond,
+					20*time.Millisecond).Should(Succeed())
+			},
+		},
 	}
-	interval := 50 * time.Millisecond
-	lr := shuttle.NewRenewLockHandler(renewer, &interval, shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
-		message *azservicebus.ReceivedMessage) {
-		time.Sleep(150 * time.Millisecond)
-	}))
-	msg := &azservicebus.ReceivedMessage{}
-	ctx, cancel := context.WithCancel(context.TODO())
-	cancel()
-	lr.Handle(ctx, &fakeSettler{}, msg)
-
-	g := NewWithT(t)
-	// continue periodic renewal on Renew error
-	g.Consistently(func() bool { return renewer.RenewCount == 0 }, 130*time.Millisecond, 20*time.Millisecond)
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			interval := 50 * time.Millisecond
+			lr := shuttle.NewRenewLockHandler(tc.renewer, &interval, shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
+				message *azservicebus.ReceivedMessage) {
+				time.Sleep(150 * time.Millisecond)
+			}))
+			msg := &azservicebus.ReceivedMessage{}
+			ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Millisecond)
+			defer cancel()
+			lr.Handle(ctx, &fakeSettler{}, msg)
+			tc.verify(NewWithT(t), &tc)
+		})
+	}
 }

--- a/v2/managedsettling_test.go
+++ b/v2/managedsettling_test.go
@@ -172,12 +172,11 @@ func TestDefaultOptions_CallDefaultHooks(t *testing.T) {
 	g.Expect(settler.completed).To(BeTrue())
 
 	settler = &fakeSettler{}
-	defaultOptions := defaultManagedSettlingOptions()
-	handleError(context.TODO(), defaultOptions, settler, &azservicebus.ReceivedMessage{DeliveryCount: 0}, fmt.Errorf("oops"))
+	handleError(context.TODO(), h.options, settler, &azservicebus.ReceivedMessage{DeliveryCount: 0}, fmt.Errorf("oops"))
 	g.Expect(settler.abandoned).To(BeTrue())
 
 	settler = &fakeSettler{}
-	handleError(context.TODO(), defaultOptions, settler, &azservicebus.ReceivedMessage{DeliveryCount: 6}, fmt.Errorf("oops"))
+	handleError(context.TODO(), h.options, settler, &azservicebus.ReceivedMessage{DeliveryCount: 6}, fmt.Errorf("oops"))
 	g.Expect(settler.deadlettered).To(BeTrue())
 	g.Expect(*settler.deadletterOptions.ErrorDescription).To(Equal("oops"))
 }

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -80,6 +80,7 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 
 // Start starts the processor and blocks until an error occurs or the context is canceled.
 func (p *Processor) Start(ctx context.Context) error {
+	log(ctx, "starting processor")
 	messages, err := p.receiver.ReceiveMessages(ctx, p.options.MaxConcurrency, nil)
 	log(ctx, "received ", len(messages), " messages - initial")
 	metrics.Processor.IncMessageReceived(float64(len(messages)))
@@ -97,7 +98,7 @@ func (p *Processor) Start(ctx context.Context) error {
 				break
 			}
 			messages, err := p.receiver.ReceiveMessages(ctx, maxMessages, nil)
-			log(ctx, "received ", len(messages), " messages from loop")
+			log(ctx, "received ", len(messages), " messages from processor loop")
 			metrics.Processor.IncMessageReceived(float64(len(messages)))
 			if err != nil {
 				return err

--- a/v2/processor_fake_test.go
+++ b/v2/processor_fake_test.go
@@ -3,6 +3,7 @@ package shuttle_test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 
@@ -12,35 +13,35 @@ import (
 var _ v2.MessageSettler = &fakeSettler{}
 
 type fakeSettler struct {
-	AbandonCalled    int
-	CompleteCalled   int
-	DeadLetterCalled int
-	DeferCalled      int
-	RenewCalled      int
+	AbandonCalled    atomic.Int32
+	CompleteCalled   atomic.Int32
+	DeadLetterCalled atomic.Int32
+	DeferCalled      atomic.Int32
+	RenewCalled      atomic.Int32
 }
 
 func (f *fakeSettler) AbandonMessage(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.AbandonMessageOptions) error {
-	f.AbandonCalled++
+	f.AbandonCalled.Add(1)
 	return nil
 }
 
 func (f *fakeSettler) CompleteMessage(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.CompleteMessageOptions) error {
-	f.CompleteCalled++
+	f.CompleteCalled.Add(1)
 	return nil
 }
 
 func (f *fakeSettler) DeadLetterMessage(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.DeadLetterOptions) error {
-	f.DeadLetterCalled++
+	f.DeadLetterCalled.Add(1)
 	return nil
 }
 
 func (f *fakeSettler) DeferMessage(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.DeferMessageOptions) error {
-	f.DeferCalled++
+	f.DeferCalled.Add(1)
 	return nil
 }
 
 func (f *fakeSettler) RenewMessageLock(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.RenewMessageLockOptions) error {
-	f.RenewCalled++
+	f.RenewCalled.Add(1)
 	return nil
 }
 

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -85,14 +85,11 @@ func TestProcessorStart_ContextCanceledAfterStart(t *testing.T) {
 			ReceiveInterval: to.Ptr(1 * time.Second),
 		})
 	ctx, cancel := context.WithCancel(context.Background())
-	var err error
-	go func() { err = processor.Start(ctx) }()
+	errCh := make(chan error)
+	go func() { errCh <- processor.Start(ctx) }()
 	cancel()
 	g := NewWithT(t)
-	g.Eventually(func(g Gomega) {
-		g.Expect(err).ToNot(BeNil())
-	}).Should(Succeed())
-	g.Expect(err).To(Equal(context.Canceled))
+	g.Eventually(errCh).Should(Receive(Equal(context.Canceled)))
 }
 
 func TestProcessorStart_CanSetMaxConcurrency(t *testing.T) {


### PR DESCRIPTION
The current lock-renewer is taking a relaxed approach to deciding when to stop attempting to renew. 
It exits the renewal loop on context cancellation only. all other errors are logged, but do not cause the renewer to stop.
This relies on the fact that the processor creates a separate child context per message, so when the message processing is done, the context will eventually be disposed of, causing the matching lock renewer to stop as well.

downside:
- it leaves a window where the handler has sent a message disposition (abandoned, completed, etc..) and has **not** exited yet. In these cases, the renewer can call Renew and get back an error because the lock is lost.
- if a serverside event causes unrecoverable errors, the lock renewer would also rely on context cancelation.

This PR handles this better by explicitely stopping the renewer goroutine when:

- a message has completed its handling
- The error returned is un-recoverable for the target message (LockLost/Auth)