### PR TITLE
🔊 fix log format

### DIFF
--- a/v2/lockrenewer.go
+++ b/v2/lockrenewer.go
@@ -124,7 +124,7 @@ func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *a
 			count++
 			err := plr.lockRenewer.RenewMessageLock(ctx, message, nil)
 			if err != nil {
-				log(ctx, "failed to renew lock: ", err)
+				log(ctx, fmt.Sprintf("failed to renew lock: %s", err))
 				metrics.Processor.IncMessageLockRenewedFailure(message)
 				// The context is canceled when the message handler returns from the processor.
 				// This can happen if we already entered the interval case when the message processing completes.
@@ -135,7 +135,7 @@ func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *a
 				// if the error is identified as permanent, we stop the renewal.
 				// if the error is anything else, we keep trying the renewal.
 				if plr.isPermanent(err) {
-					log(ctx, "stopping periodic renewal for message: ", message.MessageID)
+					log(ctx, fmt.Sprintf("stopping periodic renewal for message: %s", message.MessageID))
 					plr.stop(ctx)
 				}
 				continue
@@ -143,7 +143,7 @@ func (plr *peekLockRenewer) startPeriodicRenewal(ctx context.Context, message *a
 			span.AddEvent("message lock renewed", trace.WithAttributes(attribute.Int("count", count)))
 			metrics.Processor.IncMessageLockRenewedSuccess(message)
 		case <-ctx.Done():
-			log(ctx, ctx, "context done: stopping periodic renewal")
+			log(ctx, "context done: stopping periodic renewal")
 			span.AddEvent("context done: stopping message lock renewal")
 			err := ctx.Err()
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -36,6 +36,6 @@ func (l *printLogger) Error(s string) {
 
 func log(ctx context.Context, a ...any) {
 	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
-		getLogger(ctx).Info(fmt.Sprint(append(append([]any{}, time.Now().UTC(), " - "), a...)...))
+		getLogger(ctx).Info(fmt.Sprint(a...))
 	}
 }

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -34,12 +34,8 @@ func (l *printLogger) Error(s string) {
 	fmt.Println(append(append([]any{}, "ERROR - ", time.Now().UTC(), " - "), s)...)
 }
 
-func logf(ctx context.Context, format string, a ...any) {
-	log(ctx, fmt.Sprintf(format, a...))
-}
-
 func log(ctx context.Context, a ...any) {
 	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
-		logf(ctx, fmt.Sprint(a...))
+		getLogger(ctx).Info(fmt.Sprint(a...))
 	}
 }

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -34,8 +34,12 @@ func (l *printLogger) Error(s string) {
 	fmt.Println(append(append([]any{}, "ERROR - ", time.Now().UTC(), " - "), s)...)
 }
 
+func logf(ctx context.Context, format string, a ...any) {
+	log(ctx, fmt.Sprintf(format, a...))
+}
+
 func log(ctx context.Context, a ...any) {
 	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
-		getLogger(ctx).Info(fmt.Sprint(a...))
+		logf(ctx, fmt.Sprint(a...))
 	}
 }

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -36,6 +36,10 @@ func (l *printLogger) Error(s string) {
 
 func log(ctx context.Context, a ...any) {
 	if os.Getenv("GOSHUTTLE_LOG") == "ALL" {
-		getLogger(ctx).Info(fmt.Sprint(a...))
+		l := getLogger(ctx)
+		if l == nil {
+			return
+		}
+		l.Info(fmt.Sprint(a...))
 	}
 }

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -11,6 +11,8 @@ type testLogger struct {
 	entries []string
 }
 
+var testlogkey = struct{}{}
+
 func (t *testLogger) Info(s string) {
 	t.entries = append(t.entries, s)
 }
@@ -22,7 +24,7 @@ func (t *testLogger) Error(s string) {
 }
 
 func getTestLogger(ctx context.Context) Logger {
-	if l, ok := ctx.Value("testlogger").(*testLogger); ok {
+	if l, ok := ctx.Value(testlogkey).(*testLogger); ok {
 		return l
 	}
 	return nil
@@ -35,7 +37,7 @@ func TestSetLoggerFunc(t *testing.T) {
 	})
 	defer SetLoggerFunc(func(_ context.Context) Logger { return &printLogger{} })
 	logger := &testLogger{}
-	ctx := context.WithValue(context.Background(), "testlogger", logger)
+	ctx := context.WithValue(context.Background(), testlogkey, logger)
 	log(ctx, "test")
 	g := NewWithT(t)
 	g.Expect(getLogger(ctx)).To(Equal(logger))
@@ -45,7 +47,7 @@ func TestSetLoggerFunc(t *testing.T) {
 	g.Expect(func() { log(ctx, nil) }).ToNot(Panic())
 
 	// getLogger returns nil
-	nilCtx := context.WithValue(context.Background(), "testlogger", nil)
+	nilCtx := context.WithValue(context.Background(), testlogkey, nil)
 	g.Expect(func() { log(nilCtx, "test") }).ToNot(Panic())
 
 	//coverage on testlogger

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -16,11 +16,9 @@ func (t *testLogger) Info(s string) {
 }
 
 func (t *testLogger) Warn(s string) {
-	//TODO implement me
 }
 
 func (t *testLogger) Error(s string) {
-	//TODO implement me
 }
 
 func getTestLogger(ctx context.Context) Logger {
@@ -49,4 +47,8 @@ func TestSetLoggerFunc(t *testing.T) {
 	// getLogger returns nil
 	nilCtx := context.WithValue(context.Background(), "testlogger", nil)
 	g.Expect(func() { log(nilCtx, "test") }).ToNot(Panic())
+
+	//coverage on testlogger
+	logger.Warn("test")
+	logger.Error("test")
 }

--- a/v2/logging_test.go
+++ b/v2/logging_test.go
@@ -1,32 +1,52 @@
-package shuttle_test
+package shuttle
 
 import (
 	"context"
 	"testing"
 
-	"github.com/Azure/go-shuttle/v2"
+	. "github.com/onsi/gomega"
 )
 
-type testLogger struct{}
+type testLogger struct {
+	entries []string
+}
 
-func (t testLogger) Info(s string) {
+func (t *testLogger) Info(s string) {
+	t.entries = append(t.entries, s)
+}
+
+func (t *testLogger) Warn(s string) {
 	//TODO implement me
 }
 
-func (t testLogger) Warn(s string) {
+func (t *testLogger) Error(s string) {
 	//TODO implement me
 }
 
-func (t testLogger) Error(s string) {
-	//TODO implement me
-}
-
-func getLogger(_ context.Context) shuttle.Logger {
-	return &testLogger{}
+func getTestLogger(ctx context.Context) Logger {
+	if l, ok := ctx.Value("testlogger").(*testLogger); ok {
+		return l
+	}
+	return nil
 }
 
 func TestSetLoggerFunc(t *testing.T) {
-	shuttle.SetLoggerFunc(func(ctx context.Context) shuttle.Logger {
-		return getLogger(ctx)
+	t.Setenv("GOSHUTTLE_LOG", "ALL")
+	SetLoggerFunc(func(ctx context.Context) Logger {
+		return getTestLogger(ctx)
 	})
+	defer SetLoggerFunc(func(_ context.Context) Logger { return &printLogger{} })
+	logger := &testLogger{}
+	ctx := context.WithValue(context.Background(), "testlogger", logger)
+	log(ctx, "test")
+	g := NewWithT(t)
+	g.Expect(getLogger(ctx)).To(Equal(logger))
+	g.Expect(logger.entries).To(HaveLen(1))
+	g.Expect(logger.entries[0]).To(Equal("test"))
+
+	g.Expect(func() { log(ctx, nil) }).ToNot(Panic())
+
+	// getLogger returns nil
+	nilCtx := context.WithValue(context.Background(), "testlogger", nil)
+	g.Expect(func() { log(nilCtx, "test") }).ToNot(Panic())
 }

--- a/v2/managedsettling.go
+++ b/v2/managedsettling.go
@@ -165,7 +165,7 @@ func handleError(ctx context.Context,
 		handleErr = fmt.Errorf("nil error: %w", handleErr)
 	}
 	if !options.RetryDecision.CanRetry(handleErr, message) {
-		log(ctx, "moving message to dead letter queue because processing failed to an error: %s", handleErr)
+		log(ctx, fmt.Sprintf("moving message to dead letter queue because processing failed to an error: %s", handleErr))
 		deadLetterSettlement.settle(ctx, settler, message, &azservicebus.DeadLetterOptions{
 			Reason:             to.Ptr("ManagedSettlingHandlerDeadLettering"),
 			ErrorDescription:   to.Ptr(handleErr.Error()),
@@ -178,7 +178,7 @@ func handleError(ctx context.Context,
 	// the delay is implemented as an in-memory sleep before calling abandon.
 	// this will continue renewing the lock on the message while we wait for this delay to pass.
 	delay := options.RetryDelayStrategy.GetDelay(message.DeliveryCount)
-	log(ctx, "delay strategy return delay of %s", delay)
+	log(ctx, fmt.Sprintf("delay strategy return delay of %s", delay))
 	time.Sleep(delay)
 	abandonSettlement.settle(ctx, settler, message, nil)
 	options.OnAbandoned(ctx, message, handleErr)

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -2,6 +2,7 @@ package shuttle
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -77,11 +78,11 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 func (p *Processor) Start(ctx context.Context) error {
 	log(ctx, "starting processor")
 	messages, err := p.receiver.ReceiveMessages(ctx, p.options.MaxConcurrency, nil)
-	log(ctx, "received ", len(messages), " messages - initial")
-	metrics.Processor.IncMessageReceived(float64(len(messages)))
 	if err != nil {
 		return err
 	}
+	log(ctx, fmt.Sprintf("received %d messages - initial", len(messages)))
+	metrics.Processor.IncMessageReceived(float64(len(messages)))
 	for _, msg := range messages {
 		p.process(ctx, msg)
 	}
@@ -93,11 +94,11 @@ func (p *Processor) Start(ctx context.Context) error {
 				break
 			}
 			messages, err := p.receiver.ReceiveMessages(ctx, maxMessages, nil)
-			log(ctx, "received ", len(messages), " messages from processor loop")
-			metrics.Processor.IncMessageReceived(float64(len(messages)))
 			if err != nil {
 				return err
 			}
+			log(ctx, fmt.Sprintf("received %d messages from processor loop", len(messages)))
+			metrics.Processor.IncMessageReceived(float64(len(messages)))
 			for _, msg := range messages {
 				p.process(ctx, msg)
 			}


### PR DESCRIPTION
Remove the Timestamp prefix in the log helper function.
It should only be added on the internal printlogger for console log testing