### PR TITLE
fix: respecting context cancelation since sdk does not

### DIFF
--- a/v2/sender.go
+++ b/v2/sender.go
@@ -69,7 +69,7 @@ func (d *Sender) SendMessage(ctx context.Context, mb MessageBody, options ...fun
 	errChan := make(chan error)
 
 	go func() {
-		if err := d.sbSender.SendMessage(ctx, msg, nil); err != nil {
+		if err := d.sbSender.SendMessage(ctx, msg, nil); err != nil { // sendMessageOptions currently does nothing
 			errChan <- fmt.Errorf("failed to send message: %w", err)
 		}
 		errChan <- nil

--- a/v2/sender.go
+++ b/v2/sender.go
@@ -144,7 +144,7 @@ func (d *Sender) SendMessageBatch(ctx context.Context, messages []*azservicebus.
 
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("failed to send message: %w", ctx.Err())
+		return fmt.Errorf("failed to send message batch: %w", ctx.Err())
 	case err := <-errChan:
 		return err
 	}


### PR DESCRIPTION
Adding explicit context handling since azure sdk has shown to not respect timeouts