### PR TITLE
adding explicit context check before sends

### DIFF
--- a/v2/sender.go
+++ b/v2/sender.go
@@ -58,6 +58,12 @@ func NewSender(sender AzServiceBusSender, options *SenderOptions) *Sender {
 // SendMessage sends a payload on the bus.
 // the MessageBody is marshalled and set as the message body.
 func (d *Sender) SendMessage(ctx context.Context, mb MessageBody, options ...func(msg *azservicebus.Message) error) error {
+	// Check if there is a context error before doing anything since
+	// we rely on context failures to detect if the sender is dead.
+	if ctx.Err() != nil {
+		return fmt.Errorf("failed to send message: %w", ctx.Err())
+	}
+	
 	msg, err := d.ToServiceBusMessage(ctx, mb, options...)
 	if err != nil {
 		return err
@@ -124,6 +130,12 @@ func (d *Sender) ToServiceBusMessage(
 
 // SendMessageBatch sends the array of azservicebus messages as a batch.
 func (d *Sender) SendMessageBatch(ctx context.Context, messages []*azservicebus.Message) error {
+	// Check if there is a context error before doing anything since
+	// we rely on context failures to detect if the sender is dead.
+	if ctx.Err() != nil {
+		return fmt.Errorf("failed to send message: %w", ctx.Err())
+	}
+	
 	batch, err := d.sbSender.NewMessageBatch(ctx, &azservicebus.MessageBatchOptions{})
 	if err != nil {
 		return err

--- a/v2/sender_test.go
+++ b/v2/sender_test.go
@@ -254,21 +254,6 @@ func TestSender_SendMessageBatch(t *testing.T) {
 	// No way to create a MessageBatch struct with a non-0 max bytes in test, so the best we can do is expect an error.
 }
 
-func TestSender_SendMessageBatchWithContextCanceled(t *testing.T) {
-	g := NewWithT(t)
-	azSender := &fakeAzSender{}
-	sender := NewSender(azSender, nil)
-
-	// Create a canceled context
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := sender.SendMessageBatch(ctx, []*azservicebus.Message{})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(MatchError(context.Canceled))
-	g.Expect(azSender.SendMessageBatchCalled).To(BeFalse())
-}
-
 func TestSender_AzSender(t *testing.T) {
 	g := NewWithT(t)
 	azSender := &fakeAzSender{}


### PR DESCRIPTION
This change is to explicitly check if the context is already canceled before attempting any Send operation. 

This will protect our send failure metrics from callers who may not respect a context properly before passing it to us. 

It also helps us isolate where timeouts are occurring within the stack.

