### PR TITLE
🐛 fix: do not count context errors as failure to renew a lock

### DIFF
--- a/v2/metrics/processor/types.go
+++ b/v2/metrics/processor/types.go
@@ -17,12 +17,13 @@ const (
 )
 
 var (
-	metricsRegistry = newRegistry()
+	metricsRegistry = NewRegistry()
 	// Metric exposes a Recorder interface to manipulate the Processor metrics.
 	Metric Recorder = metricsRegistry
 )
 
-func newRegistry() *Registry {
+// NewRegistry creates a new Registry with initialized prometheus counter definitions
+func NewRegistry() *Registry {
 	return &Registry{
 		MessageReceivedCount: prom.NewCounterVec(prom.CounterOpts{
 			Name:      "message_received_total",
@@ -59,6 +60,7 @@ func getMessageTypeLabel(msg *azservicebus.ReceivedMessage) prom.Labels {
 	}
 }
 
+// Init registers the counters from the Registry on the prometheus.Registerer
 func (m *Registry) Init(reg prom.Registerer) {
 	reg.MustRegister(
 		m.MessageReceivedCount,
@@ -68,6 +70,7 @@ func (m *Registry) Init(reg prom.Registerer) {
 		m.ConcurrentMessageCount)
 }
 
+// Registry provides the prometheus metrics for the message processor
 type Registry struct {
 	MessageReceivedCount        *prom.CounterVec
 	MessageHandledCount         *prom.CounterVec
@@ -137,7 +140,12 @@ type Informer struct {
 
 // NewInformer creates an Informer for the current registry
 func NewInformer() *Informer {
-	return &Informer{registry: metricsRegistry}
+	return NewInformerFor(metricsRegistry)
+}
+
+// NewInformerFor creates an Informer for the current registry
+func NewInformerFor(r *Registry) *Informer {
+	return &Informer{registry: r}
 }
 
 // GetMessageLockRenewedFailureCount retrieves the current value of the MessageLockRenewedFailureCount metric

--- a/v2/metrics/processor/types_test.go
+++ b/v2/metrics/processor/types_test.go
@@ -26,7 +26,7 @@ func (f *fakeRegistry) Unregister(c prometheus.Collector) bool {
 
 func TestRegistry_Init(t *testing.T) {
 	g := NewWithT(t)
-	r := newRegistry()
+	r := NewRegistry()
 	fRegistry := &fakeRegistry{}
 	g.Expect(func() { r.Init(prometheus.NewRegistry()) }).ToNot(Panic())
 	g.Expect(func() { r.Init(fRegistry) }).ToNot(Panic())
@@ -55,7 +55,7 @@ func TestMetrics(t *testing.T) {
 		},
 	} {
 		g := NewWithT(t)
-		r := newRegistry()
+		r := NewRegistry()
 		registerer := prometheus.NewRegistry()
 		informer := &Informer{registry: r}
 

--- a/v2/metrics/processor/types_test.go
+++ b/v2/metrics/processor/types_test.go
@@ -32,7 +32,12 @@ func TestRegistry_Init(t *testing.T) {
 	g.Expect(func() { r.Init(fRegistry) }).ToNot(Panic())
 	g.Expect(fRegistry.collectors).To(HaveLen(5))
 	Metric.IncMessageReceived(10)
+}
 
+func TestNewInformerDefault(t *testing.T) {
+	i := NewInformer()
+	g := NewWithT(t)
+	g.Expect(i.registry).To(Equal(Metric))
 }
 
 func TestMetrics(t *testing.T) {
@@ -57,7 +62,7 @@ func TestMetrics(t *testing.T) {
 		g := NewWithT(t)
 		r := NewRegistry()
 		registerer := prometheus.NewRegistry()
-		informer := &Informer{registry: r}
+		informer := NewInformerFor(r)
 
 		// before init
 		count, err := informer.GetMessageLockRenewedFailureCount()


### PR DESCRIPTION
fixes #211 