### PR TITLE
Enable Configuration of Processor.Start() Retries

### DIFF
--- a/v2/managedsettling.go
+++ b/v2/managedsettling.go
@@ -65,20 +65,6 @@ func (d *MaxAttemptsRetryDecision) CanRetry(_ error, message *azservicebus.Recei
 	return message.DeliveryCount < d.MaxAttempts
 }
 
-// RetryDelayStrategy can be implemented to provide custom delay retry strategies.
-type RetryDelayStrategy interface {
-	GetDelay(deliveryCount uint32) time.Duration
-}
-
-// ConstantDelayStrategy delays the message retry by the given duration
-type ConstantDelayStrategy struct {
-	Delay time.Duration
-}
-
-func (s *ConstantDelayStrategy) GetDelay(_ uint32) time.Duration {
-	return s.Delay
-}
-
 // ManagedSettlingOptions allows to configure the ManagedSettling middleware
 type ManagedSettlingOptions struct {
 	// Allows to override the built-in error handling logic.

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -91,7 +91,8 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 
 // Start starts the processor and blocks until an error occurs or the context is canceled.
 // It will retry starting the processor based on the StartMaxAttempt and StartRetryDelayStrategy.
-// Returns the last error encountered while starting the processor.
+// Returns a combined list of errors during the start attempts or ctx.Err() if the context
+// is cancelled during the retries.
 func (p *Processor) Start(ctx context.Context) error {
 	var savedError error
 	for attempt := 0; attempt < p.options.StartMaxAttempt; attempt++ {
@@ -106,7 +107,7 @@ func (p *Processor) Start(ctx context.Context) error {
 				continue
 			case <-ctx.Done():
 				log(ctx, "context done, stop retrying")
-				return savedError
+				return ctx.Err()
 			}
 		}
 	}

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -107,11 +107,11 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 // Returns the last error encountered while starting the processor.
 func (p *Processor) Start(ctx context.Context) error {
 	var savedError error
-	for attempt := 1; attempt <= p.options.StartMaxAttempt; attempt++ {
+	for attempt := 0; attempt < p.options.StartMaxAttempt; attempt++ {
 		if err := p.start(ctx); err != nil {
 			savedError = err
 			log(ctx, fmt.Sprintf("processor start attempt %d failed: %v", attempt, err))
-			if attempt == p.options.StartMaxAttempt {
+			if attempt+1 == p.options.StartMaxAttempt { // last attempt, return early
 				break
 			}
 			select {

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -84,7 +84,7 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 		if options.ReceiveInterval != nil {
 			opts.ReceiveInterval = options.ReceiveInterval
 		}
-		if options.MaxConcurrency >= 0 {
+		if options.MaxConcurrency > 0 {
 			opts.MaxConcurrency = options.MaxConcurrency
 		}
 		if options.StartMaxAttempt > 0 {

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -92,7 +92,7 @@ func TestProcessorStart_ContextCanceledAfterStart(t *testing.T) {
 	go func() { errCh <- processor.Start(ctx) }()
 	cancel()
 	g := NewWithT(t)
-	g.Eventually(errCh).Should(Receive(Equal(context.Canceled)))
+	g.Eventually(errCh).Should(Receive(MatchError(context.Canceled)))
 }
 
 func TestProcessorStart_CanSetMaxConcurrency(t *testing.T) {
@@ -221,22 +221,24 @@ func TestProcessorStart_CanSetStartMaxAttempt(t *testing.T) {
 	a := require.New(t)
 	messages := make(chan *azservicebus.ReceivedMessage, 1)
 	close(messages)
+	receiveError := fmt.Errorf("fake receive error")
 	rcv := &fakeReceiver{
 		fakeSettler:           &fakeSettler{},
 		SetupReceivedMessages: messages,
 		SetupMaxReceiveCalls:  5,
-		SetupReceiveError:     fmt.Errorf("fake receive error"),
+		SetupReceiveError:     receiveError,
 	}
 
 	processor := shuttle.NewProcessor(rcv, MyHandler(0*time.Second), &shuttle.ProcessorOptions{
 		MaxConcurrency:          1,
 		StartMaxAttempt:         3,
-		StartRetryDelayStrategy: &shuttle.FixedStartDelayStrategy{Delay: 20 * time.Millisecond},
+		StartRetryDelayStrategy: &shuttle.ConstantDelayStrategy{Delay: 20 * time.Millisecond},
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	err := processor.Start(ctx)
-	a.EqualError(err, "fake receive error")
+	// matchError
+	a.ErrorIs(err, receiveError)
 	a.Equal(3, len(rcv.ReceiveCalls), "there should be 3 connection retries")
 	a.Equal(1, rcv.ReceiveCalls[0], "the processor should have used the default max concurrency of 1")
 	a.Equal(1, rcv.ReceiveCalls[1], "the processor should have used the default max concurrency of 1")
@@ -249,22 +251,23 @@ func TestProcessorStart_ContextCanceledDuringStartRetry(t *testing.T) {
 	a := require.New(t)
 	messages := make(chan *azservicebus.ReceivedMessage, 1)
 	close(messages)
+	receiveError := fmt.Errorf("fake receive error")
 	rcv := &fakeReceiver{
 		fakeSettler:           &fakeSettler{},
 		SetupReceivedMessages: messages,
 		SetupMaxReceiveCalls:  10,
-		SetupReceiveError:     fmt.Errorf("fake receive error"),
+		SetupReceiveError:     receiveError,
 	}
 
 	processor := shuttle.NewProcessor(rcv, MyHandler(0*time.Second), &shuttle.ProcessorOptions{
 		MaxConcurrency:          1,
 		StartMaxAttempt:         5,
-		StartRetryDelayStrategy: &shuttle.FixedStartDelayStrategy{Delay: 20 * time.Millisecond},
+		StartRetryDelayStrategy: &shuttle.ConstantDelayStrategy{Delay: 20 * time.Millisecond},
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	err := processor.Start(ctx)
-	a.EqualError(err, "fake receive error")
+	a.ErrorIs(err, receiveError)
 	a.Equal(2, len(rcv.ReceiveCalls), "there should be 2 connection retries")
 	a.Equal(1, rcv.ReceiveCalls[0], "the processor should have used the default max concurrency of 1")
 	a.Equal(1, rcv.ReceiveCalls[1], "the processor should have retried the receive call once")

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -81,6 +81,7 @@ func TestProcessorStart_ContextCanceledAfterStart(t *testing.T) {
 	rcv := &fakeReceiver{
 		fakeSettler:           &fakeSettler{},
 		SetupReceivedMessages: messages,
+		SetupMaxReceiveCalls:  2,
 	}
 	processor := shuttle.NewProcessor(rcv, MyHandler(0*time.Millisecond),
 		&shuttle.ProcessorOptions{

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -267,7 +267,7 @@ func TestProcessorStart_ContextCanceledDuringStartRetry(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	err := processor.Start(ctx)
-	a.ErrorIs(err, receiveError)
+	a.ErrorIs(err, context.DeadlineExceeded)
 	a.Equal(2, len(rcv.ReceiveCalls), "there should be 2 connection retries")
 	a.Equal(1, rcv.ReceiveCalls[0], "the processor should have used the default max concurrency of 1")
 	a.Equal(1, rcv.ReceiveCalls[1], "the processor should have retried the receive call once")

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -236,7 +236,7 @@ func TestProcessorStart_CanSetStartMaxAttempt(t *testing.T) {
 	defer cancel()
 	err := processor.Start(ctx)
 	a.EqualError(err, "fake receive error")
-	a.Equal(3, len(rcv.ReceiveCalls), "there should be 5 connection retries")
+	a.Equal(3, len(rcv.ReceiveCalls), "there should be 3 connection retries")
 	a.Equal(1, rcv.ReceiveCalls[0], "the processor should have used the default max concurrency of 1")
 	a.Equal(1, rcv.ReceiveCalls[1], "the processor should have used the default max concurrency of 1")
 	a.Equal(1, rcv.ReceiveCalls[2], "the processor should have used the default max concurrency of 1")

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -1,0 +1,17 @@
+package shuttle
+
+import "time"
+
+// RetryDelayStrategy can be implemented to provide custom delay retry strategies.
+type RetryDelayStrategy interface {
+	GetDelay(attempt uint32) time.Duration
+}
+
+// ConstantDelayStrategy delays the message retry by the given duration
+type ConstantDelayStrategy struct {
+	Delay time.Duration
+}
+
+func (s *ConstantDelayStrategy) GetDelay(_ uint32) time.Duration {
+	return s.Delay
+}


### PR DESCRIPTION
This PR enables retries on `Processor.Start()`. Users can configure this with `StartMaxAttempt` and `StartRetryDelayStrategy`. `Start()` returns the last error encountered while starting the processor 