### PR TITLE
Refractor LockRenewer and Enable Compatibility with MultiProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ It allows concurrent message handling and provides a message handler middleware 
 // StartMaxAttempt defaults to 1 if not set (no retries). Not setting StartMaxAttempt, or setting it to non-positive value will fallback to the default.
 // StartRetryDelayStrategy defaults to a fixed 5-second delay if not set.
 type ProcessorOptions struct {
-MaxConcurrency  int
-ReceiveInterval *time.Duration
-
-StartMaxAttempt         int
-StartRetryDelayStrategy RetryDelayStrategy
+    MaxConcurrency  int
+    ReceiveInterval *time.Duration
+    
+    StartMaxAttempt         int
+    StartRetryDelayStrategy RetryDelayStrategy
 }
 ```
 

--- a/v2/lockrenewer.go
+++ b/v2/lockrenewer.go
@@ -31,9 +31,8 @@ type LockRenewalOptions struct {
 	MetricRecorder processor.Recorder
 }
 
-// NewRenewLockHandler
-// NewLockRenewalHandlerV2 returns a middleware handler that will renew the lock on the message at the specified interval.
-func NewLockRenewalHandlerV2(options *LockRenewalOptions, handler Handler) HandlerFunc {
+// NewRenewLockHandler returns a middleware handler that will renew the lock on the message at the specified interval.
+func NewRenewLockHandler(options *LockRenewalOptions, handler Handler) HandlerFunc {
 	interval := 10 * time.Second
 	cancelMessageContextOnStop := true
 	metricRecorder := processor.Metric
@@ -65,7 +64,7 @@ func NewLockRenewalHandlerV2(options *LockRenewalOptions, handler Handler) Handl
 	}
 }
 
-// Deprecated: use NewLockRenewalHandlerV2
+// Deprecated: use NewRenewLockHandler
 // NewLockRenewalHandler returns a middleware handler that will renew the lock on the message at the specified interval.
 func NewLockRenewalHandler(lockRenewer LockRenewer, options *LockRenewalOptions, handler Handler) HandlerFunc {
 	interval := 10 * time.Second

--- a/v2/lockrenewer_test.go
+++ b/v2/lockrenewer_test.go
@@ -17,16 +17,17 @@ import (
 	"github.com/Azure/go-shuttle/v2/metrics/processor"
 )
 
-type fakeSBLockRenewer struct {
-	RenewCount atomic.Int32
+type fakeSBRenewLockSettler struct {
+	fakeSettler
+
 	PerMessage map[*azservicebus.ReceivedMessage]*atomic.Int32
 	mapLock    sync.Mutex
 	Err        error
 }
 
-func (r *fakeSBLockRenewer) RenewMessageLock(ctx context.Context, message *azservicebus.ReceivedMessage,
+func (r *fakeSBRenewLockSettler) RenewMessageLock(ctx context.Context, message *azservicebus.ReceivedMessage,
 	_ *azservicebus.RenewMessageLockOptions) error {
-	r.RenewCount.Add(1)
+	r.RenewCalled.Add(1)
 	r.mapLock.Lock()
 	defer r.mapLock.Unlock()
 	if r.PerMessage == nil {
@@ -44,11 +45,10 @@ func (r *fakeSBLockRenewer) RenewMessageLock(ctx context.Context, message *azser
 }
 
 func Test_StopRenewingOnHandlerCompletion(t *testing.T) {
-	renewer := &fakeSBLockRenewer{}
-	settler := &fakeSettler{}
+	settler := &fakeSBRenewLockSettler{}
 	g := NewWithT(t)
 	interval := 100 * time.Millisecond
-	lr := shuttle.NewLockRenewalHandler(renewer, &shuttle.LockRenewalOptions{Interval: &interval},
+	lr := shuttle.NewRenewLockHandler(&shuttle.LockRenewalOptions{Interval: &interval},
 		shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
 			message *azservicebus.ReceivedMessage) {
 			err := settler.CompleteMessage(ctx, message, nil)
@@ -60,17 +60,16 @@ func Test_StopRenewingOnHandlerCompletion(t *testing.T) {
 	lr.Handle(ctx, settler, msg)
 	g.Expect(settler.CompleteCalled.Load()).To(Equal(int32(1)))
 	g.Consistently(
-		func(g Gomega) { g.Expect(renewer.RenewCount.Load()).To(Equal(int32(0))) },
+		func(g Gomega) { g.Expect(settler.RenewCalled.Load()).To(Equal(int32(0))) },
 		130*time.Millisecond,
 		20*time.Millisecond).Should(Succeed())
 }
 
 func Test_RenewalHandlerStayIndependentPerMessage(t *testing.T) {
-	renewer := &fakeSBLockRenewer{}
-	settler := &fakeSettler{}
+	settler := &fakeSBRenewLockSettler{}
 	g := NewWithT(t)
 	interval := 50 * time.Millisecond
-	lr := shuttle.NewLockRenewalHandler(renewer, &shuttle.LockRenewalOptions{Interval: &interval},
+	lr := shuttle.NewRenewLockHandler(&shuttle.LockRenewalOptions{Interval: &interval},
 		shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
 			message *azservicebus.ReceivedMessage) {
 			// Sleep > 100ms to allow 2 renewal to happen
@@ -94,9 +93,9 @@ func Test_RenewalHandlerStayIndependentPerMessage(t *testing.T) {
 	cancel2()
 	g.Eventually(
 		func(g Gomega) {
-			g.Expect(renewer.PerMessage[msg2]).To(BeNil(), "msg2 should not be in the map")
-			g.Expect(renewer.PerMessage[msg1]).ToNot(BeNil(), "msg1 should be in the map")
-			g.Expect(renewer.PerMessage[msg1].Load()).To(Equal(int32(2)))
+			g.Expect(settler.PerMessage[msg2]).To(BeNil(), "msg2 should not be in the map")
+			g.Expect(settler.PerMessage[msg1]).ToNot(BeNil(), "msg1 should be in the map")
+			g.Expect(settler.PerMessage[msg1].Load()).To(Equal(int32(2)))
 		},
 		200*time.Millisecond,
 		10*time.Millisecond).Should(Succeed())
@@ -110,9 +109,9 @@ func Test_RenewalHandlerStayIndependentPerMessage(t *testing.T) {
 }
 
 func Test_RenewPeriodically(t *testing.T) {
-	renewer := &fakeSBLockRenewer{}
+	settler := &fakeSBRenewLockSettler{}
 	interval := 50 * time.Millisecond
-	lr := shuttle.NewLockRenewalHandler(renewer, &shuttle.LockRenewalOptions{Interval: &interval},
+	lr := shuttle.NewRenewLockHandler(&shuttle.LockRenewalOptions{Interval: &interval},
 		shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
 			message *azservicebus.ReceivedMessage) {
 			time.Sleep(150 * time.Millisecond)
@@ -120,10 +119,30 @@ func Test_RenewPeriodically(t *testing.T) {
 	msg := &azservicebus.ReceivedMessage{}
 	ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Millisecond)
 	defer cancel()
-	lr.Handle(ctx, &fakeSettler{}, msg)
+	lr.Handle(ctx, settler, msg)
 	g := NewWithT(t)
 	g.Eventually(
-		func(g Gomega) { g.Expect(renewer.RenewCount.Load()).To(Equal(int32(2))) },
+		func(g Gomega) { g.Expect(settler.RenewCalled.Load()).To(Equal(int32(2))) },
+		130*time.Millisecond,
+		20*time.Millisecond).Should(Succeed())
+}
+
+//nolint:staticcheck // still need to cover the deprecated func
+func Test_NewLockRenewalHandler_RenewPeriodically(t *testing.T) {
+	settler := &fakeSBRenewLockSettler{}
+	interval := 50 * time.Millisecond
+	lr := shuttle.NewLockRenewalHandler(settler, &shuttle.LockRenewalOptions{Interval: &interval},
+		shuttle.HandlerFunc(func(ctx context.Context, settler shuttle.MessageSettler,
+			message *azservicebus.ReceivedMessage) {
+			time.Sleep(150 * time.Millisecond)
+		}))
+	msg := &azservicebus.ReceivedMessage{}
+	ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Millisecond)
+	defer cancel()
+	lr.Handle(ctx, settler, msg)
+	g := NewWithT(t)
+	g.Eventually(
+		func(g Gomega) { g.Expect(settler.RenewCalled.Load()).To(Equal(int32(2))) },
 		130*time.Millisecond,
 		20*time.Millisecond).Should(Succeed())
 }
@@ -131,7 +150,7 @@ func Test_RenewPeriodically(t *testing.T) {
 func Test_RenewPeriodically_Error(t *testing.T) {
 	type testCase struct {
 		name              string
-		renewer           *fakeSBLockRenewer
+		settler           *fakeSBRenewLockSettler
 		isRenewerCanceled bool
 		cancelCtxOnStop   *bool
 		gotMessageCtx     context.Context
@@ -140,10 +159,10 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    "continue periodic renewal on unknown error",
-			renewer: &fakeSBLockRenewer{Err: fmt.Errorf("unknown error")},
+			settler: &fakeSBRenewLockSettler{Err: fmt.Errorf("unknown error")},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Eventually(
-					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					func(g Gomega) { g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(2))) },
 					130*time.Millisecond,
 					20*time.Millisecond).Should(Succeed())
 			},
@@ -151,11 +170,11 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 		{
 			name:              "stop periodic renewal on context canceled",
 			isRenewerCanceled: false,
-			renewer:           &fakeSBLockRenewer{Err: context.Canceled},
+			settler:           &fakeSBRenewLockSettler{Err: context.Canceled},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Consistently(
 					func(g Gomega) {
-						g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(1)),
+						g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(1)),
 							"should not attempt to renew")
 						g.Expect(metrics.GetMessageLockRenewedFailureCount()).To(Equal(float64(0)),
 							"should not record failure metric")
@@ -167,30 +186,30 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 		{
 			name:              "stop periodic renewal on context canceled",
 			isRenewerCanceled: true,
-			renewer:           &fakeSBLockRenewer{Err: context.Canceled},
+			settler:           &fakeSBRenewLockSettler{Err: context.Canceled},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Consistently(
-					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(0))) },
+					func(g Gomega) { g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(0))) },
 					130*time.Millisecond,
 					20*time.Millisecond).Should(Succeed())
 			},
 		},
 		{
 			name:    "stop periodic renewal on permanent error (lockLost)",
-			renewer: &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
+			settler: &fakeSBRenewLockSettler{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Consistently(
-					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(1))) },
+					func(g Gomega) { g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(1))) },
 					130*time.Millisecond,
 					20*time.Millisecond).Should(Succeed())
 			},
 		},
 		{
 			name:    "cancel message context on stop by default",
-			renewer: &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
+			settler: &fakeSBRenewLockSettler{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Consistently(
-					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(1))) },
+					func(g Gomega) { g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(1))) },
 					130*time.Millisecond,
 					20*time.Millisecond).Should(Succeed())
 				g.Expect(tc.gotMessageCtx.Err()).To(Equal(context.Canceled))
@@ -198,12 +217,12 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 		},
 		{
 			name:            "does not cancel message context on stop if disabled",
-			renewer:         &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
+			settler:         &fakeSBRenewLockSettler{Err: &azservicebus.Error{Code: azservicebus.CodeLockLost}},
 			cancelCtxOnStop: to.Ptr(false),
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Consistently(
 					func(g Gomega) {
-						g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(1)))
+						g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(1)))
 						g.Expect(tc.gotMessageCtx.Err()).To(BeNil())
 					},
 					100*time.Millisecond,
@@ -212,10 +231,10 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 		},
 		{
 			name:    "continue periodic renewal on transient error (timeout)",
-			renewer: &fakeSBLockRenewer{Err: &azservicebus.Error{Code: azservicebus.CodeTimeout}},
+			settler: &fakeSBRenewLockSettler{Err: &azservicebus.Error{Code: azservicebus.CodeTimeout}},
 			verify: func(g Gomega, tc *testCase, metrics *processor.Informer) {
 				g.Eventually(
-					func(g Gomega) { g.Expect(tc.renewer.RenewCount.Load()).To(Equal(int32(2))) },
+					func(g Gomega) { g.Expect(tc.settler.RenewCalled.Load()).To(Equal(int32(2))) },
 					140*time.Millisecond,
 					20*time.Millisecond).Should(Succeed())
 			},
@@ -229,7 +248,7 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 			reg := processor.NewRegistry()
 			reg.Init(prometheus.NewRegistry())
 			informer := processor.NewInformerFor(reg)
-			lr := shuttle.NewLockRenewalHandler(tc.renewer,
+			lr := shuttle.NewRenewLockHandler(
 				&shuttle.LockRenewalOptions{
 					Interval:                   &interval,
 					CancelMessageContextOnStop: tc.cancelCtxOnStop,
@@ -251,7 +270,7 @@ func Test_RenewPeriodically_Error(t *testing.T) {
 				cancel()
 			}
 			defer cancel()
-			lr.Handle(ctx, &fakeSettler{}, msg)
+			lr.Handle(ctx, tc.settler, msg)
 			tc.verify(NewWithT(t), &tc, informer)
 		})
 	}

--- a/v2/managedsettling_example_test.go
+++ b/v2/managedsettling_example_test.go
@@ -27,7 +27,7 @@ func ExampleNewManagedSettlingHandler() {
 	lockRenewalInterval := 10 * time.Second
 	p := shuttle.NewProcessor(receiver,
 		shuttle.NewPanicHandler(nil,
-			shuttle.NewLockRenewalHandler(receiver, &shuttle.LockRenewalOptions{Interval: &lockRenewalInterval},
+			shuttle.NewRenewLockHandler(&shuttle.LockRenewalOptions{Interval: &lockRenewalInterval},
 				shuttle.NewManagedSettlingHandler(&shuttle.ManagedSettlingOptions{
 					RetryDecision:      &shuttle.MaxAttemptsRetryDecision{MaxAttempts: 2},
 					RetryDelayStrategy: &shuttle.ConstantDelayStrategy{Delay: 2 * time.Second},

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -97,6 +97,7 @@ func applyProcessorOptions(options *ProcessorOptions) *ProcessorOptions {
 	return opts
 }
 
+// NewProcessor creates a new processor with the provided receiver and handler.
 func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOptions) *Processor {
 	opts := applyProcessorOptions(options)
 	receiverEx := NewReceiverEx("receiver", receiver)
@@ -108,6 +109,7 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 	}
 }
 
+// NewMultiProcessor creates a new processor with a list of receivers and a handler.
 func NewMultiProcessor(receiversEx []*ReceiverEx, handler HandlerFunc, options *ProcessorOptions) *Processor {
 	opts := applyProcessorOptions(options)
 	var receivers = make(map[string]*ReceiverEx)

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -59,7 +59,7 @@ func ExampleProcessor() {
 	cancel()
 }
 
-func ExampleProcessor_MultiProcessor() {
+func ExampleProcessor_multiProcessor() {
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		panic(err)

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -59,7 +59,7 @@ func ExampleProcessor() {
 	cancel()
 }
 
-func ExampleMultiProcessor() {
+func ExampleProcessor_MultiProcessor() {
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		panic(err)
@@ -537,6 +537,45 @@ func TestProcessorStart_TwoPanics(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("panic recovered from processor testReceiver1: receive panic!"))
 	g.Expect(err.Error()).To(ContainSubstring("panic recovered from processor testReceiver2: receive panic!"))
+}
+
+func TestProcessorStart_MultiProcessorWithNewRenewLockHandler(t *testing.T) {
+	rcv1 := &fakeReceiver{
+		fakeSettler:           &fakeSettler{},
+		SetupReceivedMessages: messagesChannel(1),
+		SetupMaxReceiveCalls:  2,
+	}
+	close(rcv1.SetupReceivedMessages)
+	rcv2 := &fakeReceiver{
+		fakeSettler:           &fakeSettler{},
+		SetupReceivedMessages: messagesChannel(1),
+		SetupMaxReceiveCalls:  2,
+	}
+	close(rcv2.SetupReceivedMessages)
+	rcvs := []*shuttle.ReceiverEx{
+		shuttle.NewReceiverEx("testReceiver1", rcv1),
+		shuttle.NewReceiverEx("testReceiver2", rcv2),
+	}
+	lockRenewalInterval := 50 * time.Millisecond
+	lockRenewalOptions := &shuttle.LockRenewalOptions{Interval: &lockRenewalInterval}
+	processor := shuttle.NewMultiProcessor(rcvs,
+		shuttle.NewRenewLockHandler(lockRenewalOptions, MyHandler(150*time.Millisecond)),
+		&shuttle.ProcessorOptions{
+			MaxConcurrency: 2,
+		})
+	ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Millisecond)
+	defer cancel()
+	err := processor.Start(ctx)
+	g := NewWithT(t)
+	g.Expect(err).To(HaveOccurred())
+	g.Eventually(
+		func(g Gomega) { g.Expect(rcv1.RenewCalled.Load()).To(Equal(int32(2))) },
+		130*time.Millisecond,
+		20*time.Millisecond).Should(Succeed())
+	g.Eventually(
+		func(g Gomega) { g.Expect(rcv2.RenewCalled.Load()).To(Equal(int32(2))) },
+		130*time.Millisecond,
+		20*time.Millisecond).Should(Succeed())
 }
 
 func messagesChannel(messageCount int) chan *azservicebus.ReceivedMessage {

--- a/v2/settlehandler_example_test.go
+++ b/v2/settlehandler_example_test.go
@@ -26,7 +26,7 @@ func ExampleNewSettlementHandler() {
 	lockRenewalInterval := 10 * time.Second
 	p := shuttle.NewProcessor(receiver,
 		shuttle.NewPanicHandler(nil,
-			shuttle.NewLockRenewalHandler(receiver, &shuttle.LockRenewalOptions{Interval: &lockRenewalInterval},
+			shuttle.NewRenewLockHandler(&shuttle.LockRenewalOptions{Interval: &lockRenewalInterval},
 				shuttle.NewSettlementHandler(nil, mySettlingHandler()))), &shuttle.ProcessorOptions{MaxConcurrency: 10})
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
- Refractor `NewLockRenewalHandler` to `NewRenewLockHandler`. The refractor gets rid of the lockRenewer argument in the constructor and instead uses the settler passed down from the handler function. 
- Deprecate `NewLockRenewalHandler`
- The refractor also enables compatibility with MultiProcessor. The lock renewal handler now will automatically take in the correct settler for each receiver in the MultiProcessor.
  - Added UT to verify compatibility.