### PR TITLE
Rename sender.FailOver() to sender.SetAzSender()

### DIFF
--- a/v2/sender.go
+++ b/v2/sender.go
@@ -206,14 +206,19 @@ func (d *Sender) AzSender() AzServiceBusSender {
 	return d.sbSender
 }
 
-// FailOver sets the underlying azservicebus.Sender instance to the provided one.
-// This is used when the traffic needs to be failed over to a different sender instance.
+// SetAzSender sets the underlying azservicebus.Sender instance to the provided one.
 // All ongoing send operations will continue to use the old sender instance,
 // while new send operations will use the new sender instance.
-func (d *Sender) FailOver(sender AzServiceBusSender) {
+func (d *Sender) SetAzSender(sender AzServiceBusSender) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.sbSender = sender
+}
+
+// Deprecated: use SetAzSender.
+// FailOver sets the underlying azservicebus.Sender instance to the provided one.
+func (d *Sender) FailOver(sender AzServiceBusSender) {
+	d.SetAzSender(sender)
 }
 
 // SetMessageId sets the ServiceBus message's ID to a user-specified value

--- a/v2/sender_test.go
+++ b/v2/sender_test.go
@@ -262,18 +262,18 @@ func TestSender_AzSender(t *testing.T) {
 	g.Expect(sender.AzSender()).To(Equal(azSender))
 }
 
-func TestSender_FailOver(t *testing.T) {
+func TestSender_SetAzSender(t *testing.T) {
 	g := NewWithT(t)
 	azSender := &fakeAzSender{SendMessageErr: fmt.Errorf("msg send failure")}
 	sender := NewSender(azSender, nil)
 	err := sender.SendMessage(context.Background(), "test")
 	g.Expect(err).To(HaveOccurred())
-	sender.FailOver(&fakeAzSender{})
+	sender.SetAzSender(&fakeAzSender{})
 	err = sender.SendMessage(context.Background(), "test")
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
-func TestSender_ConcurrentSendAndFailOver(t *testing.T) {
+func TestSender_ConcurrentSendAndSetAzSender(t *testing.T) {
 	g := NewWithT(t)
 	azSender1 := &fakeAzSender{}
 	azSender2 := &fakeAzSender{}
@@ -294,9 +294,9 @@ func TestSender_ConcurrentSendAndFailOver(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 		}(i)
 	}
-	// call FailOver in the middle
+	// call SetAzSender in the middle
 	time.Sleep(5 * time.Millisecond)
-	sender.FailOver(azSender2)
+	sender.SetAzSender(azSender2)
 	// wait for all goroutines to finish
 	wg.Wait()
 	// check that some messages were sent with the first sender and some with the second

--- a/v2/sender_test.go
+++ b/v2/sender_test.go
@@ -271,6 +271,8 @@ func TestSender_SetAzSender(t *testing.T) {
 	sender.SetAzSender(&fakeAzSender{})
 	err = sender.SendMessage(context.Background(), "test")
 	g.Expect(err).ToNot(HaveOccurred())
+	// coverage for deprecated FailOver() function
+	sender.FailOver(&fakeAzSender{})
 }
 
 func TestSender_ConcurrentSendAndSetAzSender(t *testing.T) {


### PR DESCRIPTION
Rename sender.FailOver() to sender.SetAzSender()