### PR TITLE
Expose az sender Close()

### DIFF
--- a/v2/sender.go
+++ b/v2/sender.go
@@ -25,6 +25,7 @@ type AzServiceBusSender interface {
 	SendMessage(ctx context.Context, message *azservicebus.Message, options *azservicebus.SendMessageOptions) error
 	SendMessageBatch(ctx context.Context, batch *azservicebus.MessageBatch, options *azservicebus.SendMessageBatchOptions) error
 	NewMessageBatch(ctx context.Context, options *azservicebus.MessageBatchOptions) (*azservicebus.MessageBatch, error)
+	Close(ctx context.Context) error
 }
 
 // Sender contains an SBSender used to send the message to the ServiceBus queue and a Marshaller used to marshal any struct into a ServiceBus message

--- a/v2/sender_test.go
+++ b/v2/sender_test.go
@@ -330,6 +330,7 @@ type fakeAzSender struct {
 	NewMessageBatchReturnValue    *azservicebus.MessageBatch
 	NewMessageBatchErr            error
 	SendMessageBatchReceivedValue *azservicebus.MessageBatch
+	CloseErr                      error
 }
 
 func (f *fakeAzSender) SendMessage(
@@ -369,4 +370,8 @@ func (f *fakeAzSender) NewMessageBatch(
 	ctx context.Context,
 	options *azservicebus.MessageBatchOptions) (*azservicebus.MessageBatch, error) {
 	return f.NewMessageBatchReturnValue, f.NewMessageBatchErr
+}
+
+func (f *fakeAzSender) Close(ctx context.Context) error {
+	return f.CloseErr
 }


### PR DESCRIPTION
Expose AzSender Close()

After calling SetAzSender(), we want to be able to close the previous underlying AzSender connection to avoid taking up the connection quota.