### PR TITLE
Deprecate MultiProcessor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ type ProcessorOptions struct {
 
 ### MultiProcessor
 
-`NewMultiProcessor` takes in a list of receivers and a message handler. It creates a processor for each receiver and starts them concurrently.
-
-see [Processor and MultiProcessor examples](v2/processor_test.go)
+Deprecated: `NewMultiProcessor`, `ReceiverEx`, and `NewReceiverEx` are deprecated and will be removed in a future major version.
+Use `NewProcessor` with one receiver per processor instead.
 
 ## Middlewares:
 GoSHuttle provides a few middleware to simplify the implementation of the message handler in the application code

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ type ProcessorOptions struct {
 
 ### MultiProcessor
 
-Deprecated: `NewMultiProcessor`, `ReceiverEx`, and `NewReceiverEx` are deprecated and will be removed in a future major version.
+Deprecated: `NewMultiProcessor`, `ReceiverEx`, and `NewReceiverEx` are deprecated and will be removed in a future version.
 Use `NewProcessor` with one receiver per processor instead.
 
 ## Middlewares:

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -28,7 +28,7 @@ type MessageSettler interface {
 
 // ReceiverEx names a Service Bus receiver for NewMultiProcessor.
 //
-// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future version.
 // Use NewProcessor with one receiver per Processor instead.
 type ReceiverEx struct { // shuttle.Receiver is already an exported interface
 	name       string
@@ -37,7 +37,7 @@ type ReceiverEx struct { // shuttle.Receiver is already an exported interface
 
 // NewReceiverEx creates a named receiver for NewMultiProcessor.
 //
-// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future version.
 // Use NewProcessor with one receiver per Processor instead.
 func NewReceiverEx(name string, sbReceiver Receiver) *ReceiverEx {
 	return &ReceiverEx{
@@ -133,7 +133,7 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 
 // NewMultiProcessor creates a new processor with a list of receivers and a handler.
 //
-// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future version.
 // Use NewProcessor with one receiver per Processor instead.
 func NewMultiProcessor(receiversEx []*ReceiverEx, handler HandlerFunc, options *ProcessorOptions) *Processor {
 	opts := applyProcessorOptions(options)

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -26,11 +26,19 @@ type MessageSettler interface {
 	RenewMessageLock(ctx context.Context, message *azservicebus.ReceivedMessage, options *azservicebus.RenewMessageLockOptions) error
 }
 
+// ReceiverEx names a Service Bus receiver for NewMultiProcessor.
+//
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Use NewProcessor with one receiver per Processor instead.
 type ReceiverEx struct { // shuttle.Receiver is already an exported interface
 	name       string
 	sbReceiver Receiver
 }
 
+// NewReceiverEx creates a named receiver for NewMultiProcessor.
+//
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Use NewProcessor with one receiver per Processor instead.
 func NewReceiverEx(name string, sbReceiver Receiver) *ReceiverEx {
 	return &ReceiverEx{
 		name:       name,
@@ -124,6 +132,9 @@ func NewProcessor(receiver Receiver, handler HandlerFunc, options *ProcessorOpti
 }
 
 // NewMultiProcessor creates a new processor with a list of receivers and a handler.
+//
+// Deprecated: NewMultiProcessor is deprecated and will be removed in a future major version.
+// Use NewProcessor with one receiver per Processor instead.
 func NewMultiProcessor(receiversEx []*ReceiverEx, handler HandlerFunc, options *ProcessorOptions) *Processor {
 	opts := applyProcessorOptions(options)
 	var receivers = make(map[string]*ReceiverEx)


### PR DESCRIPTION
## Summary
- mark NewMultiProcessor as deprecated ahead of future removal
- mark the companion ReceiverEx and NewReceiverEx APIs as deprecated
- update the README MultiProcessor section to direct users to NewProcessor instead

## Verification
- go test ./... (from v2)
- go vet ./... (from v2)
- git diff --check

Note: PR #280 remains draft for the later removal after a deprecation release is tagged.